### PR TITLE
Update languages.json to remove Brazilian Portuguese as it is not available at LibreTranslate

### DIFF
--- a/lingarr_api/src/statics/languages.json
+++ b/lingarr_api/src/statics/languages.json
@@ -44,10 +44,6 @@
         "code": "bs"
     },
     {
-        "name": "Brazilian Portuguese",
-        "code": "pt-BR"
-    },
-    {
         "name": "Bulgarian",
         "code": "bg"
     },


### PR DESCRIPTION
Submitting a PR to fix https://github.com/lingarr-translate/lingarr/issues/5

Selecting Brazilian Portuguese will render an empty translated document due to the pt-br language not being available in LibreTranslate.

I also created this issue on LibreTranslate to include support for Brazilian Portuguese: https://github.com/argosopentech/argos-translate/issues/401