### PR TITLE
Fix progress bar max-width

### DIFF
--- a/Lingarr.Client/src/pages/TranslationPage.vue
+++ b/Lingarr.Client/src/pages/TranslationPage.vue
@@ -112,7 +112,7 @@
                         <TranslationStatus :translation-status="item.status" />
                     </div>
                     <div
-                        class="mb-2 flex max-w-64 items-center md:mb-0 md:px-4 md:py-2"
+                        class="mb-2 flex items-center md:mb-0 md:px-4 md:py-2"
                         :class="isSelectMode ? 'md:col-span-2' : 'md:col-span-3'">
                         <div
                             v-if="item.status === TRANSLATION_STATUS.INPROGRESS && item.progress"

--- a/Lingarr.Client/src/pages/TranslationPage.vue
+++ b/Lingarr.Client/src/pages/TranslationPage.vue
@@ -112,7 +112,7 @@
                         <TranslationStatus :translation-status="item.status" />
                     </div>
                     <div
-                        class="mb-2 flex max-w-6 items-center md:mb-0 md:px-4 md:py-2"
+                        class="mb-2 flex max-w-64 items-center md:mb-0 md:px-4 md:py-2"
                         :class="isSelectMode ? 'md:col-span-2' : 'md:col-span-3'">
                         <div
                             v-if="item.status === TRANSLATION_STATUS.INPROGRESS && item.progress"


### PR DESCRIPTION
The progress bar is not showing due to the max-width being too small (--spacing of .25rem combined with max-w-6 results in a max width of 24px). Changing it to 64 seems a nice value.

Fixes #118 
