### PR TITLE
Fix subtitle missing from the frontend episode table

### DIFF
--- a/Lingarr.Client/src/components/features/show/EpisodeTable.vue
+++ b/Lingarr.Client/src/components/features/show/EpisodeTable.vue
@@ -69,7 +69,7 @@ const getSubtitle = (fileName: string | null) => {
     return props.subtitles
         .filter(
             (subtitle: ISubtitle) =>
-                subtitle.fileName.includes(fileName) &&
+                subtitle.fileName.toLocaleLowerCase().includes(fileName.toLocaleLowerCase()) &&
                 subtitle.language &&
                 subtitle.language.trim() !== ''
         )


### PR DESCRIPTION
Fixes the issue where the subtitles would not appear in the episode table because the file name had a difference in upper case/lower case. It now compares both file names in lower case so it is case insesitive