### PR TITLE
Fix failed translation not being updated correctly by WS for the frontend

### DIFF
--- a/Lingarr.Server/Jobs/TranslationJob.cs
+++ b/Lingarr.Server/Jobs/TranslationJob.cs
@@ -245,9 +245,11 @@ public class TranslationJob
         catch (Exception)
         {
             await _translationRequestService.ClearMediaHash(translationRequest);
-            await _translationRequestService.UpdateTranslationRequest(translationRequest, TranslationStatus.Failed,
+            translationRequest = await _translationRequestService.UpdateTranslationRequest(translationRequest, TranslationStatus.Failed,
                 jobId);
             await _scheduleService.UpdateJobState(jobName, JobStatus.Failed.GetDisplayName());
+            await _translationRequestService.UpdateActiveCount();
+            await _progressService.Emit(translationRequest, 0);
             throw;
         }
     }


### PR DESCRIPTION
There was 2 issues making the WS sync not correct with the frontend
1) the translationRequest was updated by using _translationRequestService.UpdateTranslationRequest but the return value was not used which made the current translationRequest in the context of the caller not change to be a failed request so I overwrote translationRequest with the return value
2) The UpdateActiveCount was not called to make the frontend update

I also added the Emit line that sets the progress to 0, I don't think it's really needed but it is also done in the HandleCancellation so I figured it would be better to follow how it's handled in other places