### PR TITLE
Add a retry action for TranslationRequests

### DIFF
--- a/Lingarr.Client/src/components/common/TranslationAction.vue
+++ b/Lingarr.Client/src/components/common/TranslationAction.vue
@@ -22,7 +22,6 @@ const props = defineProps<{
     onAction: (action: TRANSLATION_ACTIONS) => Promise<void>,
 }>()
 
-const emit = defineEmits(['toggle:action'])
 const loading = ref(false)
 
 const inProgress = computed(() => props.status === TRANSLATION_STATUS.INPROGRESS)

--- a/Lingarr.Client/src/pages/TranslationPage.vue
+++ b/Lingarr.Client/src/pages/TranslationPage.vue
@@ -72,7 +72,7 @@
                     <div class="deletable float-right h-5 w-5 md:hidden">
                         <TranslationAction
                             :status="item.status"
-                            @toggle:action="(action) => handleAction(item, action)" />
+                            :onAction="(action) => handleAction(item, action)" />
                     </div>
                     <div class="mb-2 md:col-span-4 md:mb-0 md:px-4 md:py-2">
                         <span :id="`deletable-${item.id}`" class="font-bold md:hidden">
@@ -136,7 +136,7 @@
                         <div class="flex h-5 w-5 items-center justify-center">
                             <TranslationAction
                                 :status="item.status"
-                                @toggle:action="(action) => handleAction(item, action)" />
+                                :onAction="(action) => handleAction(item, action)" />
                         </div>
                     </div>
                     <div
@@ -169,6 +169,7 @@ import {
     IPagedResult,
     ITranslationRequest,
     MEDIA_TYPE,
+    TRANSLATION_ACTIONS,
     TRANSLATION_STATUS
 } from '@/ts'
 import { useTranslationRequestStore } from '@/store/translationRequest'
@@ -201,12 +202,17 @@ const filter: ComputedRef<IFilter> = computed({
     }, 300)
 })
 
-function handleAction(translationRequest: ITranslationRequest, action: string) {
-    if (!action) return
-    if (action === 'cancel') {
-        return translationRequestStore.cancel(translationRequest)
+async function handleAction(translationRequest: ITranslationRequest, action: TRANSLATION_ACTIONS) {
+    switch (action) {
+        case TRANSLATION_ACTIONS.CANCEL:
+            return await translationRequestStore.cancel(translationRequest)
+        case TRANSLATION_ACTIONS.REMOVE:
+            return await translationRequestStore.remove(translationRequest)
+        case TRANSLATION_ACTIONS.RETRY:
+            return await translationRequestStore.retry(translationRequest)
+        default:
+            console.error("unknown translation request action: " + action);
     }
-    return translationRequestStore.remove(translationRequest)
 }
 
 onMounted(async () => {

--- a/Lingarr.Client/src/services/translationRequestService.ts
+++ b/Lingarr.Client/src/services/translationRequestService.ts
@@ -60,6 +60,17 @@ const service = (
                     reject(error.response)
                 })
         })
+    },
+    retry<T>(translationRequest: ITranslationRequest): Promise<T> {
+        return new Promise((resolve, reject) => {
+            http.post(`${resource}/retry`, translationRequest)
+                .then((response: AxiosResponse<T>) => {
+                    resolve(response.data)
+                })
+                .catch((error: AxiosError) => {
+                    reject(error.response)
+                })
+        });
     }
 })
 

--- a/Lingarr.Client/src/store/translationRequest.ts
+++ b/Lingarr.Client/src/store/translationRequest.ts
@@ -70,6 +70,9 @@ export const useTranslationRequestStore = defineStore({
                 )
             })
         },
+        async retry(translationRequest: ITranslationRequest) {
+            await services.translationRequest.retry<string>(translationRequest)
+        },
         async updateProgress(requestProgress: IRequestProgress) {
             this.translationRequests.items = this.translationRequests.items.map(
                 (request: ITranslationRequest) => {

--- a/Lingarr.Client/src/ts/media/index.ts
+++ b/Lingarr.Client/src/ts/media/index.ts
@@ -108,3 +108,9 @@ export const TRANSLATION_STATUS = {
 } as const
 
 export type TranslationStatus = (typeof TRANSLATION_STATUS)[keyof typeof TRANSLATION_STATUS]
+
+export enum TRANSLATION_ACTIONS {
+    CANCEL,
+    REMOVE,
+    RETRY,
+}

--- a/Lingarr.Client/src/ts/services.ts
+++ b/Lingarr.Client/src/ts/services.ts
@@ -76,6 +76,7 @@ export interface ITranslationRequestService {
     ): Promise<T>
     cancel<T>(translationRequest: ITranslationRequest): Promise<T>
     remove<T>(translationRequest: ITranslationRequest): Promise<T>
+    retry<T>(translationRequest: ITranslationRequest): Promise<T>
 }
 
 export interface IScheduleService {

--- a/Lingarr.Server/Controllers/TranslationRequestController.cs
+++ b/Lingarr.Server/Controllers/TranslationRequestController.cs
@@ -16,7 +16,7 @@ public class TranslationRequestController : ControllerBase
     {
         _translationRequestService = translationRequestService;
     }
-    
+
     /// <summary>
     /// Gets the count of active translation requests
     /// </summary>
@@ -29,7 +29,7 @@ public class TranslationRequestController : ControllerBase
         var activeCount = await _translationRequestService.GetActiveCount();
         return Ok(activeCount);
     }
-    
+
     /// <summary>
     /// Retrieves a paginated list of translation requests with optional filtering and sorting
     /// </summary>
@@ -49,16 +49,16 @@ public class TranslationRequestController : ControllerBase
         int pageSize = 20,
         int pageNumber = 1)
     {
-            var value = await _translationRequestService.GetTranslationRequests(
-                searchQuery,
-                orderBy,
-                ascending,
-                pageNumber,
-                pageSize);
+        var value = await _translationRequestService.GetTranslationRequests(
+            searchQuery,
+            orderBy,
+            ascending,
+            pageNumber,
+            pageSize);
 
-            return Ok(value);
+        return Ok(value);
     }
-    
+
     /// <summary>
     /// Cancels an existing translation request
     /// </summary>
@@ -78,7 +78,7 @@ public class TranslationRequestController : ControllerBase
 
         return NotFound(translationRequest);
     }
-    
+
     /// <summary>
     /// Removes an existing translation request
     /// </summary>
@@ -97,5 +97,27 @@ public class TranslationRequestController : ControllerBase
         }
 
         return NotFound(translationRequest);
+    }
+
+    /// <summary>
+    /// Retries an existing translation request
+    /// Does not delete the current one, just reques
+    /// The request with the same information
+    /// </summary>
+    /// <param name="retryRequest">The translation request to retry</param>
+    /// <response code="200">Returns the new translation request</response>
+    /// <response code="404">If the translation request was not found</response>
+    /// <response code="500">If there was an error checking for updates</response>
+    /// <returns>ActionResult containing the new translation request if found, or NotFound if the request doesn't exist</returns>
+    [HttpPost("retry")]
+    public async Task<ActionResult<string>> RetryTranslationRequest([FromBody] TranslationRequest retryRequest)
+    {
+        var newTranslationRequest = await _translationRequestService.RetryTranslationRequest(retryRequest);
+        if (newTranslationRequest != null)
+        {
+            return Ok(newTranslationRequest);
+        }
+
+        return NotFound(newTranslationRequest);
     }
 }

--- a/Lingarr.Server/Interfaces/Services/ITranslationRequestService.cs
+++ b/Lingarr.Server/Interfaces/Services/ITranslationRequestService.cs
@@ -17,6 +17,13 @@ public interface ITranslationRequestService
     Task<int> CreateRequest(TranslateAbleSubtitle translateAbleSubtitle);
 
     /// <summary>
+    /// Creates a new translation request from a translationRequest, creating a new one with the same exact settings.
+    /// </summary>
+    /// <param name="translationRequest">Translation request to copie</param>
+    /// <returns>The ID of the created translation request</returns>
+    Task<int> CreateRequest(TranslationRequest translationRequest);
+
+    /// <summary>
     /// Retrieves the count of active translation requests.
     /// </summary>
     /// <returns>Number of translation requests that are neither Cancelled nor Completed</returns>
@@ -61,6 +68,17 @@ public interface ITranslationRequestService
     /// </returns>
     Task<string?> RemoveTranslationRequest(
         TranslationRequest cancelRequest
+    );
+
+    /// <summary>
+    /// Retries an existing translation request
+    /// </summary>
+    /// <param name="retryRequest">The translation request to retry</param>
+    /// <returns>
+    /// A message indicating the result of the new transaltion request, or null if the request wasn't found
+    /// </returns>
+    Task<string?> RetryTranslationRequest(
+        TranslationRequest retryRequest
     );
 
     /// <summary>


### PR DESCRIPTION
This PR adds a retry action button on the frontend to quickly retry a translation request.
If one transaltion request fails, the user can click this button to retry the translation.
It will not impact the current failed translation, it will only create a new translation request with identical options (subtitle file, languages, etc)

Currently, the retry button is shown when a translation request is removable (COMPLETED, CANCELLED, FAILED or INTERRUPTED).
It may not be desired to have it shown on completed translation requests but for now it is shown using the same condition as the remove action

The button is using the Reload icon, maybe using an other icon would be more meaningful
Let me know what you think!