### PR TITLE
Fix white space on right side and bottom when scrollable

### DIFF
--- a/Lingarr.Client/index.html
+++ b/Lingarr.Client/index.html
@@ -7,7 +7,7 @@
     <title>Lingarr - Turbocharged Subtitle Translation</title>
 </head>
   <body>
-    <div id="app"></div>
+    <div id="app" style="overflow: hidden;"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/Lingarr.Client/src/components/common/TranslationAction.vue
+++ b/Lingarr.Client/src/components/common/TranslationAction.vue
@@ -1,19 +1,29 @@
 ﻿<template>
-    <button :disabled="loading">
-        <LoaderCircleIcon v-if="loading" class="h-5 w-5 animate-spin" />
-        <TimesIcon
-            v-else-if="inProgress"
-            class="h-5 w-5 cursor-pointer"
-            @click="executeAction(TRANSLATION_ACTIONS.CANCEL)" />
-        <div v-else-if="removable" class="flex space-x-2">
-            <RetryIcon
-                class="h-5 w-5 cursor-pointer"
-                @click="executeAction(TRANSLATION_ACTIONS.RETRY)" />
-            <TrashIcon
-                class="h-5 w-5 cursor-pointer"
-                @click="executeAction(TRANSLATION_ACTIONS.REMOVE)" />
-        </div>
-    </button>
+    <div v-if="loading" class="md:px-4">
+        <LoaderCircleIcon class="h-5 w-5 animate-spin" />
+    </div>
+    <div v-else-if="inProgress">
+        <button 
+            :disabled="loading" 
+            class="md:px-4"
+            @click="executeAction(TRANSLATION_ACTIONS.CANCEL)">
+            <TimesIcon class="h-5 w-5 cursor-pointer" />
+        </button>
+    </div>
+    <div v-else-if="removable" class="md:space-x-2">
+        <button 
+            :disabled="loading" 
+            class="cursor-pointer"
+            @click="executeAction(TRANSLATION_ACTIONS.RETRY)">
+                <RetryIcon class="h-5 w-5" />
+                </button>
+        <button 
+            :disabled="loading" 
+            class="cursor-pointer"
+            @click="executeAction(TRANSLATION_ACTIONS.REMOVE)">
+            <TrashIcon class="h-5 w-5" />
+        </button>
+    </div>
 </template>
 
 <script setup lang="ts">

--- a/Lingarr.Client/src/pages/TranslationPage.vue
+++ b/Lingarr.Client/src/pages/TranslationPage.vue
@@ -69,7 +69,7 @@
                     v-for="item in translationRequests.items"
                     :key="item.id"
                     class="md:border-accent rounded-lg py-4 shadow-sm md:grid md:grid-cols-12 md:rounded-none md:border-b md:bg-transparent md:p-0 md:shadow-none">
-                    <div class="deletable float-right h-5 w-5 md:hidden">
+                    <div class="deletable float-right w-5 md:hidden">
                         <TranslationAction
                             :status="item.status"
                             :onAction="(action) => handleAction(item, action)" />
@@ -132,8 +132,8 @@
                             :completed-at="item.completedAt" />
                     </div>
                     <div
-                        class="hidden items-center justify-between md:col-span-1 md:flex md:justify-end md:px-4 md:py-2">
-                        <div class="flex h-5 w-5 items-center justify-center">
+                        class="hidden items-center justify-between md:col-span-1 md:flex md:justify-end md:py-2">
+                        <div class="flex items-center justify-center">
                             <TranslationAction
                                 :status="item.status"
                                 :onAction="(action) => handleAction(item, action)" />


### PR DESCRIPTION
This PR fixes issues where it was possible to see a white background because of scrollable items that would take more space than the app element.

- Modified the TranslationActions buttons to have each a button element instead of one for all
- Changed the spacing and alignment to match better with content
- Added overflow hidden to app element, Anything that will go beyond the app element will now be hidden and won't become scrollable.