### PR TITLE
SSA parser only set dialog name if column exist

### DIFF
--- a/Lingarr.Server/Services/Subtitle/SsaParser.cs
+++ b/Lingarr.Server/Services/Subtitle/SsaParser.cs
@@ -192,12 +192,16 @@ public class SsaParser : ISubtitleParser
         {
             Marked = dialogueParts[0].Trim(),
             Style = dialogueParts[columnIndexes["Style"]].Trim(),
-            Name = dialogueParts[columnIndexes["Name"]].Trim(),
             MarginL = dialogueParts[columnIndexes["MarginL"]].Trim(),
             MarginR = dialogueParts[columnIndexes["MarginR"]].Trim(),
             MarginV = dialogueParts[columnIndexes["MarginV"]].Trim(),
             Effect = dialogueParts[columnIndexes["Effect"]].Trim()
         };
+        
+
+        if (columnIndexes.ContainsKey("Name")) {
+            ssaDialogue.Name = dialogueParts[columnIndexes["Name"]].Trim();
+        }
 
         return new SubtitleItem
         {


### PR DESCRIPTION
Conditionally set the dialog name if the column exist so it doesn't crash if name is not one of the columns

Fixes #180