### PR TITLE
feat: add GitHub Container Registry (GHCR) support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,10 +8,6 @@ on:
     types: [ published ]
   workflow_dispatch:
 
-env:
-  REGISTRY: docker.io
-  IMAGE_NAME: lingarr/lingarr
-
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -36,11 +32,20 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: |
+          docker.io/lingarr/lingarr
+          ghcr.io/${{ github.repository }}
         tags: |
           type=ref,event=branch
           type=semver,pattern={{version}}

--- a/Readme.MD
+++ b/Readme.MD
@@ -40,11 +40,22 @@ Lingarr provides multi-architecture Docker images that automatically select the 
 
 **Note:** As of 1.0.3 all images support both AMD64 (Intel/AMD) and ARM64 (Raspberry Pi, Apple Silicon) architectures. Docker will automatically pull the correct architecture for your system.
 
+### Available Registries
+
+Lingarr Docker images are available from multiple registries:
+
+| Registry | Image |
+|----------|-------|
+| Docker Hub | `docker.io/lingarr/lingarr:latest` |
+| GitHub Container Registry | `ghcr.io/lingarr-translate/lingarr:latest` |
+
+Use GHCR if you're experiencing Docker Hub rate limits.
+
 ## Setting up Lingarr
 ```yaml
 services:
   lingarr:
-    image: lingarr/lingarr:latest
+    image: lingarr/lingarr:latest  # or ghcr.io/lingarr-translate/lingarr:latest
     container_name: lingarr
     restart: unless-stopped
     environment:
@@ -77,6 +88,7 @@ docker run -d \
   -v /path/to/config:/app/config \
   --network lingarr \
   lingarr/lingarr:latest
+  # or use: ghcr.io/lingarr-translate/lingarr:latest
 ```
 
 ### Lingarr environment variables


### PR DESCRIPTION
## Summary
Adds support for publishing Docker images to GitHub Container Registry (ghcr.io) alongside Docker Hub to avoid rate limiting issues.

## Changes
- **Workflow**: Added GHCR login step using `GITHUB_TOKEN`
- **Workflow**: Updated metadata action to push to both registries simultaneously:
  - `docker.io/lingarr/lingarr`
  - `ghcr.io/lingarr-translate/lingarr`
- **Documentation**: Updated README with GHCR registry information
- **Documentation**: Added registry comparison table
- **Documentation**: Updated docker-compose and CLI examples to show GHCR option

## Benefits
- Avoids Docker Hub rate limits (especially for unauthenticated pulls)
- No additional secrets required (uses built-in `GITHUB_TOKEN`)
- Both registries stay in sync automatically
- Users can choose which registry to use

## Testing
After merge, images will be published to:
- Docker Hub: `docker.io/lingarr/lingarr:latest`
- GHCR: `ghcr.io/lingarr-translate/lingarr:latest`

Both registries will have the same tags (latest, main, version numbers) and support both amd64 and arm64 architectures.

Fixes #265