### PR TITLE
Consistent 429/503 retry handling across all translation providers

### DIFF
--- a/Lingarr.Server/Services/Translation/AnthropicService.cs
+++ b/Lingarr.Server/Services/Translation/AnthropicService.cs
@@ -158,9 +158,11 @@ public class AnthropicService : BaseLanguageService, ITranslationService, IBatch
                     await _httpClient.PostAsync($"{_endpoint}/messages", content, linked.Token);
                 if (!response.IsSuccessStatusCode)
                 {
-                    if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                    if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
                     {
-                        throw new HttpRequestException("Rate limit exceeded", null, HttpStatusCode.TooManyRequests);
+                        throw new HttpRequestException(
+                            $"Anthropic returned {response.StatusCode}",
+                            null, response.StatusCode);
                     }
 
                     _logger.LogError("Response Status Code: {StatusCode}", response.StatusCode);
@@ -174,20 +176,20 @@ public class AnthropicService : BaseLanguageService, ITranslationService, IBatch
                 var subtitleLine = jsonResponse.GetProperty("content")[0].GetProperty("text").GetString();
                 return subtitleLine ?? throw new InvalidOperationException();
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == _maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for text: {Text}", text);
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for text: {Text}", ex.StatusCode, text);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
-                
+
                 _logger.LogWarning(
-                    "Anthropic rate limit hit. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "Anthropic", ex.StatusCode, delay, attempt, _maxRetries);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -229,20 +231,20 @@ public class AnthropicService : BaseLanguageService, ITranslationService, IBatch
             {
                 return await TranslateBatchWithAnthropicApi(subtitleBatch, linked.Token);
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == _maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for batch translation");
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for batch translation", ex.StatusCode);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
-
-                _logger.LogWarning(
-                    "Anthropic rate limit hit. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
+
+                _logger.LogWarning(
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "Anthropic", ex.StatusCode, delay, attempt, _maxRetries);
             }
             catch (Exception ex)
             {
@@ -337,6 +339,13 @@ public class AnthropicService : BaseLanguageService, ITranslationService, IBatch
         var response = await _httpClient.PostAsync($"{_endpoint}/messages", content, cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
+            if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
+            {
+                throw new HttpRequestException(
+                    $"Batch translation using Anthropic failed with {response.StatusCode}.",
+                    null, response.StatusCode);
+            }
+
             _logger.LogError("Response Status Code: {StatusCode}", response.StatusCode);
             _logger.LogError("Response Content: {ResponseContent}",
                 await response.Content.ReadAsStringAsync(cancellationToken));

--- a/Lingarr.Server/Services/Translation/GTranslatorService.cs
+++ b/Lingarr.Server/Services/Translation/GTranslatorService.cs
@@ -51,17 +51,17 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
                 
                 return result.Translation;
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for text: {Text}", text);
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for text: {Text}", ex.StatusCode, text);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
 
                 _logger.LogWarning(
-                    "429 Too Many Requests. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, maxRetries);
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "GTranslator", ex.StatusCode, delay, attempt, maxRetries);
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, maxDelay.Ticks));

--- a/Lingarr.Server/Services/Translation/GoogleGeminiService.cs
+++ b/Lingarr.Server/Services/Translation/GoogleGeminiService.cs
@@ -138,35 +138,20 @@ public class GoogleGeminiService : BaseLanguageService, ITranslationService, IBa
             {
                 return await TranslateWithGeminiApi(text, linked.Token);
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == _maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for text: {Text}", text);
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for text: {Text}", ex.StatusCode, text);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
 
                 _logger.LogWarning(
-                    "Gemini rate limit hit. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable)
-            {
-                if (attempt == _maxRetries)
-                {
-                    _logger.LogError(ex, "Gemini server error, it might be down. Max retries exhausted for text: {Text}", text);
-                    throw new TranslationException("Gemini is temporarily unavailable, usually due to high load or maintenance. Retry limit reached.", ex);
-                }
-
-                await Task.Delay(delay, linked.Token).ConfigureAwait(false);
-                delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
-
-                _logger.LogWarning(
-                    "Gemini service unavailable. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "Gemini", ex.StatusCode, delay, attempt, _maxRetries);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -350,35 +335,20 @@ public class GoogleGeminiService : BaseLanguageService, ITranslationService, IBa
             {
                 return await TranslateBatchWithGeminiApi(subtitleBatch, linked.Token);
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == _maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for batch translation");
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for batch translation", ex.StatusCode);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
-
-                _logger.LogWarning(
-                    "Gemini rate limit hit. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable)
-            {
-                if (attempt == _maxRetries)
-                {
-                    _logger.LogError(ex, "Gemini server error, it might be down. Max retries exhausted for batch translation");
-                    throw new TranslationException("Gemini is temporarily unavailable, usually due to high load or maintenance. Retry limit reached.", ex);
-                }
 
                 _logger.LogWarning(
-                    "Gemini service unavailable. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
-
-                await Task.Delay(delay, linked.Token).ConfigureAwait(false);
-                delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "Gemini", ex.StatusCode, delay, attempt, _maxRetries);
             }
             catch (Exception ex)
             {

--- a/Lingarr.Server/Services/Translation/LocalAiService.cs
+++ b/Lingarr.Server/Services/Translation/LocalAiService.cs
@@ -205,20 +205,20 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
             {
                 return await TranslateBatchWithLocalAiApi(subtitleBatch, linked.Token);
             }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
             {
                 if (attempt == _maxRetries)
                 {
-                    _logger.LogError(ex, "Too many requests. Max retries exhausted for batch translation");
-                    throw new TranslationException("Too many requests. Retry limit reached.", ex);
+                    _logger.LogError(ex, "Max retries exhausted ({StatusCode}) for batch translation", ex.StatusCode);
+                    throw new TranslationException($"Retry limit reached after {ex.StatusCode}.", ex);
                 }
-
-                _logger.LogWarning(
-                    "429 Too Many Requests. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
-                    delay, attempt, _maxRetries);
 
                 await Task.Delay(delay, linked.Token).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
+
+                _logger.LogWarning(
+                    "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "LocalAI", ex.StatusCode, delay, attempt, _maxRetries);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Combine separate 429 and 503 catch blocks into a single `when` clause using `is ... or ...` across all providers (addresses review feedback from @rowanfuchs)
- Add 503 (ServiceUnavailable) retry to providers that only had 429: AnthropicService, OpenAiService (batch), GTranslatorService, LocalAiService (batch)
- Fix batch methods in OpenAiService and AnthropicService that threw `TranslationException` on 429/503 instead of `HttpRequestException`, which silently broke retry — the retry catch blocks never fired for batch failures
- Simplify catch block pattern: drop `isRateLimit` ternaries, log `ex.StatusCode` directly
- Collapse 4 retry `[Fact]` tests into 2 parameterized `[Theory]` tests
- Add retry exhaustion tests for both single and batch translation

## Files changed
| File | Change |
|---|---|
| `GoogleGeminiService.cs` | Combine two catch blocks into one (both methods) |
| `OpenAiService.cs` | Combine catch blocks + combine inner `if` blocks + fix batch `TranslationException` → `HttpRequestException` |
| `AnthropicService.cs` | Add 503 to inner check + combine catch blocks + fix batch throw |
| `GTranslatorService.cs` | Add 503 to existing 429 catch |
| `LocalAiService.cs` | Add 503 to batch catch (TranslateAsync left as-is — uses `TranslationResponseException`, different pattern) |
| `GoogleGeminiServiceTests.cs` | Parameterize retry tests, add exhaustion tests |

### Not changed
- **DeepLService** — uses `DeepL.TooManyRequestsException` (SDK-specific), can't catch on `HttpStatusCode`
- **LocalAiService.TranslateAsync** — catches `TranslationResponseException` from inner methods, different pattern; fixing would require refactoring the inner methods

## Test plan
- [x] All 55 tests pass (`dotnet test --configuration Release`)
- [x] Retry tests parameterized for both 429 and 503
- [x] Exhaustion tests verify `TranslationException` is thrown with correct message and `HttpRequestException` inner exception after max retries
- [x] Build passes with 0 errors in Release configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)