### PR TITLE
fix: resolve migration failures on fresh install

### DIFF
--- a/Lingarr.Migrations/Migrations/M0001_InitialCreate.cs
+++ b/Lingarr.Migrations/Migrations/M0001_InitialCreate.cs
@@ -10,7 +10,7 @@ public class M0001_InitialCreate : Migration
         // Settings
         Create.Table("settings")
             .WithColumn("key").AsString(255).PrimaryKey()
-            .WithColumn("value").AsString().NotNullable();
+            .WithColumn("value").AsCustom("TEXT").NotNullable();
 
         // Movies
         Create.Table("movies")

--- a/Lingarr.Server/Extensions/ApplicationBuilderExtensions.cs
+++ b/Lingarr.Server/Extensions/ApplicationBuilderExtensions.cs
@@ -40,21 +40,42 @@ public static class ApplicationBuilderExtensions
         app.MapHub<JobProgressHub>("/signalr/JobProgress");
     }
 
-    private static Task ApplyMigrations(this WebApplication app)
+    private static async Task ApplyMigrations(this WebApplication app)
     {
-        try
-        {
-            Console.WriteLine("Applying migrations...");
-            MigrationConfiguration.RunMigrations(app.Services);
-            Console.WriteLine("Migrations applied successfully.");
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"An error occurred while applying migrations: {ex}");
-            throw;
-        }
+        const int maxRetries = 10;
+        const int initialDelaySeconds = 3;
 
-        return Task.CompletedTask;
+        for (var attempt = 1; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                Console.WriteLine("Applying migrations...");
+                MigrationConfiguration.RunMigrations(app.Services);
+                Console.WriteLine("Migrations applied successfully.");
+                return;
+            }
+            catch (Exception ex) when (attempt < maxRetries && IsConnectionError(ex))
+            {
+                var delay = initialDelaySeconds * attempt;
+                Console.WriteLine(
+                    $"Database connection failed (attempt {attempt}/{maxRetries}). Retrying in {delay}s...");
+                await Task.Delay(TimeSpan.FromSeconds(delay));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"An error occurred while applying migrations: {ex}");
+                throw;
+            }
+        }
+    }
+
+    private static bool IsConnectionError(Exception ex)
+    {
+        var message = ex.ToString();
+        return message.Contains("Unable to connect") ||
+               message.Contains("Connection refused") ||
+               message.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("Too many connections", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void ConfigureSpa(this WebApplication app)


### PR DESCRIPTION
**Note: Claude Opus 4.6 was used to debug.**

**Bug 1: "Data too long for column 'value'"**
Root cause: M0001_InitialCreate.cs:13 defined the value column as .AsString(), which FluentMigrator maps to VARCHAR(255) in MySQL. The ai_prompt seed value in M0002_SeedSettings.cs:54 is ~261 characters, exceeding this limit.
Fix: Changed .AsString() to .AsCustom("TEXT") for the value column. TEXT supports up to 65,535 bytes in MySQL, which is appropriate for settings values that can contain prompts, JSON arrays, etc.

**Bug 2: "Unable to connect to any of the specified MySQL hosts"**
Root cause: ApplicationBuilderExtensions.cs:43 had no retry logic. During Docker Compose startup, the application container often starts before MySQL is fully ready to accept connections. The app would crash immediately with an unhandled exception.
Fix: Added retry logic with linear backoff (up to 10 attempts, 3s/6s/9s/.../30s delays) that specifically catches connection-related errors. Non-connection errors (like schema issues) still fail immediately.

Both bugs were introduced in the same commit:

**`b782eeb` - "Replace EF Core migrations with FluentMigrator with support for MySQL, PostgreSQL, and SQLite (#285)"**

This commit:
1. Created `M0001_InitialCreate.cs` with `.AsString()` (VARCHAR(255)) for the settings `value` column, while also creating `M0002_SeedSettings.cs` that seeds `ai_prompt` with a ~261 character string — exceeding the limit.
2. Rewrote `ApplicationBuilderExtensions.cs` with the new `ApplyMigrations` method that calls `MigrationConfiguration.RunMigrations()` without any retry logic for database readiness.