### PR TITLE
feat: add season-level selection for bulk translation

### DIFF
--- a/Lingarr.Client/src/components/features/show/SeasonTable.vue
+++ b/Lingarr.Client/src/components/features/show/SeasonTable.vue
@@ -5,12 +5,17 @@
             <div class="col-span-6 px-4 py-2 md:col-span-3">
                 {{ translate('tvShows.season') }}
             </div>
-            <div class="col-span-6 flex justify-between px-4 py-2 md:col-span-8">
+            <div
+                :class="isSelectMode ? 'md:col-span-7' : 'md:col-span-8'"
+                class="col-span-6 flex justify-between px-4 py-2">
                 <span>{{ translate('tvShows.episodes') }}</span>
                 <span class="hidden md:block">
                     {{ translate('tvShows.exclude') }}
                 </span>
                 <span class="block md:hidden">⊘</span>
+            </div>
+            <div v-if="isSelectMode" class="col-span-1 flex items-center justify-center px-4 py-2">
+                <CheckboxComponent :model-value="allSeasonsSelected" @change="toggleAllSeasons" />
             </div>
         </div>
         <!-- Seasons -->
@@ -33,7 +38,9 @@
                     </span>
                     <span v-else>{{ translate('tvShows.season') }} {{ season.seasonNumber }}</span>
                 </div>
-                <div class="col-span-6 flex justify-between px-4 py-2 select-none md:col-span-8">
+                <div
+                    :class="isSelectMode ? 'md:col-span-7' : 'md:col-span-8'"
+                    class="col-span-6 flex justify-between px-4 py-2 select-none">
                     <span>
                         {{ season.episodes.length }}
                         {{ translate('tvShows.episodesLine') }}
@@ -47,6 +54,14 @@
                             " />
                     </span>
                 </div>
+                <div
+                    v-if="isSelectMode"
+                    class="col-span-1 flex items-center justify-center px-4 py-2"
+                    @click.stop>
+                    <CheckboxComponent
+                        :model-value="!!showStore.selectedSeasons[season.id]"
+                        @change="showStore.toggleSeasonSelect(season, show)" />
+                </div>
             </div>
             <EpisodeTable
                 v-if="expandedSeason?.id === season.id"
@@ -57,19 +72,42 @@
 </template>
 
 <script setup lang="ts">
-import { ref, Ref } from 'vue'
-import { ISeason, ISubtitle, MEDIA_TYPE } from '@/ts'
+import { ref, Ref, computed } from 'vue'
+import { ISeason, IShow, ISubtitle, MEDIA_TYPE } from '@/ts'
 import EpisodeTable from '@/components/features/show/EpisodeTable.vue'
 import CaretButton from '@/components/common/CaretButton.vue'
 import ToggleButton from '@/components/common/ToggleButton.vue'
+import CheckboxComponent from '@/components/common/CheckboxComponent.vue'
 import services from '@/services'
 import { useShowStore } from '@/store/show'
 
-defineProps<{
+const props = defineProps<{
     seasons: ISeason[]
+    show: IShow
+    isSelectMode: boolean
 }>()
 
 const showStore = useShowStore()
+
+const allSeasonsSelected = computed(() =>
+    props.seasons.every((s) => showStore.selectedSeasons[s.id])
+)
+
+function toggleAllSeasons() {
+    if (allSeasonsSelected.value) {
+        for (const season of props.seasons) {
+            if (showStore.selectedSeasons[season.id]) {
+                showStore.toggleSeasonSelect(season, props.show)
+            }
+        }
+    } else {
+        for (const season of props.seasons) {
+            if (!showStore.selectedSeasons[season.id]) {
+                showStore.toggleSeasonSelect(season, props.show)
+            }
+        }
+    }
+}
 const subtitles: Ref<ISubtitle[]> = ref([])
 const expandedSeason: Ref<ISeason | null> = ref(null)
 

--- a/Lingarr.Client/src/store/show.ts
+++ b/Lingarr.Client/src/store/show.ts
@@ -1,6 +1,6 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import services from '@/services'
-import { IFilter, IUseShowStore, IPagedResult, IShow, MediaType } from '@/ts'
+import { IFilter, IUseShowStore, IPagedResult, IShow, ISeason, MediaType } from '@/ts'
 
 export const useShowStore = defineStore('show', {
     state: (): IUseShowStore => ({
@@ -17,11 +17,18 @@ export const useShowStore = defineStore('show', {
             pageNumber: 1
         },
         selectedShows: [],
+        selectedSeasons: {},
         selectAll: false
     }),
     getters: {
         getFilter: (state: IUseShowStore): IFilter => state.filter,
-        get: (state: IUseShowStore): IPagedResult<IShow> => state.shows
+        get: (state: IUseShowStore): IPagedResult<IShow> => state.shows,
+        selectedEpisodeCount: (state: IUseShowStore): number => {
+            return Object.values(state.selectedSeasons).reduce(
+                (count, season) => count + season.episodes.length,
+                0
+            )
+        }
     },
     actions: {
         async setFilter(filterVal: IFilter) {
@@ -44,14 +51,22 @@ export const useShowStore = defineStore('show', {
         },
         clearSelection() {
             this.selectedShows = []
+            this.selectedSeasons = {}
             this.selectAll = false
         },
         toggleSelectAll() {
             if (this.selectAll) {
                 this.selectedShows = []
+                this.selectedSeasons = {}
                 this.selectAll = false
             } else {
                 this.selectedShows = [...this.shows.items]
+                this.selectedSeasons = {}
+                for (const show of this.shows.items) {
+                    for (const season of show.seasons) {
+                        this.selectedSeasons[season.id] = season
+                    }
+                }
                 this.selectAll = true
             }
         },
@@ -59,8 +74,32 @@ export const useShowStore = defineStore('show', {
             const index = this.selectedShows.findIndex((s) => s.id === show.id)
             if (index === -1) {
                 this.selectedShows.push(show)
+                for (const season of show.seasons) {
+                    this.selectedSeasons[season.id] = season
+                }
             } else {
                 this.selectedShows.splice(index, 1)
+                for (const season of show.seasons) {
+                    delete this.selectedSeasons[season.id]
+                }
+            }
+            this.selectAll = this.selectedShows.length === this.shows.items.length
+        },
+        toggleSeasonSelect(season: ISeason, show: IShow) {
+            if (this.selectedSeasons[season.id]) {
+                delete this.selectedSeasons[season.id]
+                const showIndex = this.selectedShows.findIndex((s) => s.id === show.id)
+                if (showIndex !== -1) {
+                    this.selectedShows.splice(showIndex, 1)
+                }
+            } else {
+                this.selectedSeasons[season.id] = season
+                const allSeasonsSelected = show.seasons.every((s) => this.selectedSeasons[s.id])
+                if (allSeasonsSelected) {
+                    if (!this.selectedShows.some((s) => s.id === show.id)) {
+                        this.selectedShows.push(show)
+                    }
+                }
             }
             this.selectAll = this.selectedShows.length === this.shows.items.length
         }

--- a/Lingarr.Client/src/ts/store/show.ts
+++ b/Lingarr.Client/src/ts/store/show.ts
@@ -1,8 +1,9 @@
-﻿import { IFilter, IPagedResult, IShow } from '@/ts'
+﻿import { IFilter, IPagedResult, ISeason, IShow } from '@/ts'
 
 export interface IUseShowStore {
     shows: IPagedResult<IShow>
     filter: IFilter
     selectedShows: IShow[]
+    selectedSeasons: Record<number, ISeason>
     selectAll: boolean
 }


### PR DESCRIPTION
## Summary

Currently Lingarr supports translating subtitles at the individual episode level (via the context menu) or for entire shows at once (via multi-select). There's no way to translate a specific season without either clicking through every episode or selecting the whole show. This adds season-level granularity to the existing multi-select feature.

- Extends the existing multi-select to support selecting individual seasons within a show
- Show-level checkbox remains the default and acts as a "select all seasons" shortcut
- Hierarchical selection: checking all seasons auto-checks the parent show, unchecking one season unchecks the parent but keeps the rest selected
- Season table header includes a select-all checkbox matching the show-level pattern
- "Translate (n)" button now displays the total episode count with a label (e.g., "Translate (24 episodes)")

## Screenshots

<img width="946" height="668" alt="Screenshot 2026-02-08 at 15 30 14" src="https://github.com/user-attachments/assets/6531cf16-9fee-4807-8985-470c25776175" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)