### PR TITLE
Update M0001_InitialCreate.cs

### DIFF
--- a/Lingarr.Migrations/Migrations/M0001_InitialCreate.cs
+++ b/Lingarr.Migrations/Migrations/M0001_InitialCreate.cs
@@ -10,7 +10,7 @@ public class M0001_InitialCreate : Migration
         // Settings
         Create.Table("settings")
             .WithColumn("key").AsString(255).PrimaryKey()
-            .WithColumn("value").AsCustom("TEXT").NotNullable();
+            .WithColumn("value").AsCustom("LONGTEXT").NotNullable();
 
         // Movies
         Create.Table("movies")


### PR DESCRIPTION
Needed to manually change my column-type to LONGTEXT After that, the migration works.
Errolog before the column edit:
```
[2026-02-12 13:09:49] [Error] FluentMigrator.Runner.MigrationRunner: Data too long for column 'value' at row 1

MySqlConnector.MySqlException (0x80004005): Data too long for column 'value' at row 1
```