### PR TITLE
Enforce MAX_CONCURRENT_JOBS across all translation paths

### DIFF
--- a/Lingarr.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/Lingarr.Server/Extensions/ServiceCollectionExtensions.cs
@@ -148,6 +148,7 @@ public static class ServiceCollectionExtensions
 
         builder.Services.AddHostedService<ScheduleInitializationService>();
         builder.Services.AddSingleton<IScheduleService, ScheduleService>();
+        builder.Services.AddSingleton<ITranslationConcurrencyGate, TranslationConcurrencyGate>();
 
         builder.Services.AddScoped<IImageService, ImageService>();
         builder.Services.AddScoped<IIntegrationService, IntegrationService>();

--- a/Lingarr.Server/Interfaces/Services/ITranslationConcurrencyGate.cs
+++ b/Lingarr.Server/Interfaces/Services/ITranslationConcurrencyGate.cs
@@ -1,0 +1,15 @@
+namespace Lingarr.Server.Interfaces.Services;
+
+/// <summary>
+/// Caps the number of translations that can run concurrently across every code path
+/// (Hangfire jobs, HTTP API, etc.). Sized from the MAX_CONCURRENT_JOBS environment variable.
+/// </summary>
+public interface ITranslationConcurrencyGate
+{
+    /// <summary>
+    /// Waits until a translation slot is available, then returns a disposable that releases
+    /// the slot when disposed. Throws <see cref="OperationCanceledException"/> if the token
+    /// is cancelled while waiting.
+    /// </summary>
+    Task<IDisposable> AcquireAsync(CancellationToken cancellationToken);
+}

--- a/Lingarr.Server/Jobs/TranslationJob.cs
+++ b/Lingarr.Server/Jobs/TranslationJob.cs
@@ -26,6 +26,7 @@ public class TranslationJob
     private readonly ITranslationServiceFactory _translationServiceFactory;
     private readonly ITranslationRequestService _translationRequestService;
     private readonly ITranslationRequestEventService _eventService;
+    private readonly ITranslationConcurrencyGate _concurrencyGate;
 
     public TranslationJob(
         ILogger<TranslationJob> logger,
@@ -37,7 +38,8 @@ public class TranslationJob
         IStatisticsService statisticsService,
         ITranslationServiceFactory translationServiceFactory,
         ITranslationRequestService translationRequestService,
-        ITranslationRequestEventService eventService)
+        ITranslationRequestEventService eventService,
+        ITranslationConcurrencyGate concurrencyGate)
     {
         _logger = logger;
         _settings = settings;
@@ -49,6 +51,7 @@ public class TranslationJob
         _translationServiceFactory = translationServiceFactory;
         _translationRequestService = translationRequestService;
         _eventService = eventService;
+        _concurrencyGate = concurrencyGate;
     }
 
     [AutomaticRetry(Attempts = 0)]
@@ -62,6 +65,10 @@ public class TranslationJob
 
         try
         {
+            // Respect the shared MAX_CONCURRENT_JOBS limit so Hangfire-triggered translations
+            // share the same gate as API-triggered ones.
+            using var _ = await _concurrencyGate.AcquireAsync(cancellationToken);
+
             await _scheduleService.UpdateJobState(jobName, JobStatus.Processing.GetDisplayName());
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/Lingarr.Server/Services/TranslationConcurrencyGate.cs
+++ b/Lingarr.Server/Services/TranslationConcurrencyGate.cs
@@ -1,0 +1,53 @@
+using Lingarr.Server.Interfaces.Services;
+
+namespace Lingarr.Server.Services;
+
+/// <inheritdoc />
+public sealed class TranslationConcurrencyGate : ITranslationConcurrencyGate, IDisposable
+{
+    private readonly SemaphoreSlim _semaphore;
+    private readonly ILogger<TranslationConcurrencyGate> _logger;
+
+    public TranslationConcurrencyGate(ILogger<TranslationConcurrencyGate> logger)
+    {
+        _logger = logger;
+
+        var maxConcurrent =
+            int.TryParse(Environment.GetEnvironmentVariable("MAX_CONCURRENT_JOBS"), out var parsed) && parsed > 0
+                ? parsed
+                : 1;
+
+        _semaphore = new SemaphoreSlim(maxConcurrent, maxConcurrent);
+        _logger.LogInformation("Translation concurrency gate initialised with {MaxConcurrent} slot(s)", maxConcurrent);
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> AcquireAsync(CancellationToken cancellationToken)
+    {
+        if (_semaphore.CurrentCount == 0)
+        {
+            _logger.LogDebug("Translation concurrency gate is full, waiting for an available slot");
+        }
+
+        await _semaphore.WaitAsync(cancellationToken);
+        return new Releaser(_semaphore);
+    }
+
+    public void Dispose() => _semaphore.Dispose();
+
+    private sealed class Releaser : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private int _released;
+
+        public Releaser(SemaphoreSlim semaphore) => _semaphore = semaphore;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}

--- a/Lingarr.Server/Services/TranslationRequestService.cs
+++ b/Lingarr.Server/Services/TranslationRequestService.cs
@@ -30,6 +30,7 @@ public class TranslationRequestService : ITranslationRequestService
     private readonly ISettingService _settingService;
     private readonly ISubtitleService _subtitleService;
     private readonly ITranslationRequestEventService _eventService;
+    private readonly ITranslationConcurrencyGate _concurrencyGate;
     private readonly ILogger<TranslationRequestService> _logger;
     private static readonly ConcurrentDictionary<int, CancellationTokenSource> _asyncTranslationJobs = new();
 
@@ -44,6 +45,7 @@ public class TranslationRequestService : ITranslationRequestService
         ISettingService settingService,
         ISubtitleService subtitleService,
         ITranslationRequestEventService eventService,
+        ITranslationConcurrencyGate concurrencyGate,
         ILogger<TranslationRequestService> logger)
     {
         _dbContext = dbContext;
@@ -56,6 +58,7 @@ public class TranslationRequestService : ITranslationRequestService
         _settingService = settingService;
         _subtitleService = subtitleService;
         _eventService = eventService;
+        _concurrencyGate = concurrencyGate;
         _logger = logger;
     }
 
@@ -529,6 +532,10 @@ public class TranslationRequestService : ITranslationRequestService
 
         try
         {
+            // Respect the shared MAX_CONCURRENT_JOBS limit so API-triggered translations
+            // share the same gate as Hangfire-triggered ones.
+            using var _ = await _concurrencyGate.AcquireAsync(cancellationToken);
+
             BatchTranslatedLine[]? results;
             // Get Translation Settings
             var settings = await _settingService.GetSettings([


### PR DESCRIPTION
## Summary

- Adds `ITranslationConcurrencyGate`, a singleton `SemaphoreSlim` sized from `MAX_CONCURRENT_JOBS`
- Acquires the gate at the top of both translation paths (`TranslationJob.Execute` and `TranslationRequestService.TranslateContentAsync`) so the env var is authoritative regardless of dispatch path

## Why

`MAX_CONCURRENT_JOBS` currently only affects Hangfire's `WorkerCount` in `ServiceCollectionExtensions.ConfigureHangfire`. That correctly limits translations dispatched through Hangfire queues (i.e. UI-triggered jobs going through `TranslationJob`), but translations that come in over the HTTP API — specifically `POST /api/translate/content`, which is what Bazarr's Lingarr integration calls — run inline on Kestrel request threads via `TranslationRequestService.TranslateContentAsync` and are **not** bound by the Hangfire worker count.

The result is that a user running `MAX_CONCURRENT_JOBS=1` can still end up with multiple concurrent translations: one from Hangfire (UI) + one (or more) from the API (Bazarr). For users running a local LLM backend like LM Studio or Ollama — which is the exact scenario the env var is meant to protect — this causes backend contention and, depending on the backend, OOMs or model eviction.

Closes #369.

## What changed

**New interface + implementation**

- `Lingarr.Server/Interfaces/Services/ITranslationConcurrencyGate.cs`
- `Lingarr.Server/Services/TranslationConcurrencyGate.cs`

The gate is a singleton wrapping a `SemaphoreSlim(max, max)` where `max` is parsed from `MAX_CONCURRENT_JOBS` (default `1`, matching the existing Hangfire default). `AcquireAsync(ct)` returns an `IDisposable` that releases exactly once on dispose, so `using var _ = await gate.AcquireAsync(ct);` handles both happy path and exceptions.

**DI registration**

- `ServiceCollectionExtensions.cs`: `AddSingleton<ITranslationConcurrencyGate, TranslationConcurrencyGate>()` alongside the other singleton services.

**Wire-up**

- `TranslationRequestService.TranslateContentAsync`: acquires the gate as the first step inside the existing `try` block, before settings fetch and DB writes, so the existing `TaskCanceledException` / `Exception` handlers cover gate-wait cancellation.
- `TranslationJob.Execute`: same pattern — acquires the gate before `UpdateJobState(Processing)` and the rest of the job body.

## Deliberately out of scope

- I did not change the Hangfire `WorkerCount` wiring. It still reads `MAX_CONCURRENT_JOBS` for its own purposes (limiting parallelism of non-translation queues like `movies`, `shows`, `webhook`, `default`). The translation-specific gate is additive.
- I did not introduce a `Queued` status for translation requests that are waiting on the gate. For `TranslationRequestService` the DB record isn't created until after the gate is acquired, so a waiting API request is invisible in the UI. Adding a queued state is straightforward but felt like a separate change — happy to do it here if you'd prefer.
- I did not expose the current slot count anywhere (no new SignalR event, no `/status` field). Again, straightforward follow-up if you want it.

## Test plan

- [x] Builds clean against `net9.0` (`dotnet build Lingarr.Server/Lingarr.Server.csproj` — 0 errors, pre-existing warnings unchanged).
- [ ] Manual: with `MAX_CONCURRENT_JOBS=1`, trigger a translation from the Lingarr UI **and** a translation from Bazarr simultaneously. Expected: second one blocks until the first completes; neither fails. (I can verify against my own setup once this is reviewed — my local stack has both paths wired up for exactly this reason.)
- [ ] Manual: cancel a waiting API request mid-wait. Expected: `TaskCanceledException` propagates through existing handler, slot is released, no deadlock on subsequent requests.