### PR TITLE
feat: enhance UI with hover effects on episode, season, and movie tables

### DIFF
--- a/Lingarr.Client/src/components/features/show/EpisodeTable.vue
+++ b/Lingarr.Client/src/components/features/show/EpisodeTable.vue
@@ -12,7 +12,7 @@
                 <span class="block md:hidden">✓</span>
             </div>
         </div>
-        <div v-for="episode in episodes" :key="episode.id" class="grid grid-cols-12">
+        <div v-for="episode in episodes" :key="episode.id" class="grid grid-cols-12 transition-colors hover:bg-accent/5">
             <div class="col-span-1 px-4 py-2">
                 {{ episode.episodeNumber }}
             </div>

--- a/Lingarr.Client/src/components/features/show/SeasonTable.vue
+++ b/Lingarr.Client/src/components/features/show/SeasonTable.vue
@@ -15,8 +15,8 @@
             :key="season.id"
             class="bg-primary text-sm text-accent-content md:text-base">
             <div
-                class="grid grid-cols-12"
-                :class="{ 'cursor-pointer': season.episodes.length }"
+                class="grid grid-cols-12 transition-colors"
+                :class="{ 'cursor-pointer hover:bg-accent/5': season.episodes.length }"
                 @click="toggleSeason(season)">
                 <div class="col-span-6 flex select-none items-center px-4 py-2 md:col-span-3">
                     <CaretButton

--- a/Lingarr.Client/src/pages/MoviePage.vue
+++ b/Lingarr.Client/src/pages/MoviePage.vue
@@ -72,7 +72,7 @@
                 </div>
             </div>
             <div v-for="item in movies.items" :key="item.id">
-                <div class="grid grid-cols-12 border-b border-accent">
+                <div class="grid grid-cols-12 border-b border-accent transition-colors hover:bg-accent/5">
                     <div :class="isSelectMode ? 'col-span-4' : 'col-span-5'" class="px-4 py-2">
                         {{ item.title }}
                     </div>

--- a/Lingarr.Client/src/pages/TranslationPage.vue
+++ b/Lingarr.Client/src/pages/TranslationPage.vue
@@ -59,7 +59,7 @@
             <div
                 v-for="item in translationRequests.items"
                 :key="item.id"
-                class="rounded-lg py-4 shadow-sm md:grid md:grid-cols-12 md:rounded-none md:border-b md:border-accent md:bg-transparent md:p-0 md:shadow-none">
+                class="rounded-lg py-4 shadow-sm transition-colors hover:bg-accent/5 md:grid md:grid-cols-12 md:rounded-none md:border-b md:border-accent md:bg-transparent md:p-0 md:shadow-none">
                 <div class="deletable float-right md:hidden">
                     <TranslationAction
                         :item="item"


### PR DESCRIPTION
The PR improves the user experience in the `TranslationPage`, `EpisodeTable`, `SeasonTable`, and `MoviePage` with visual feedback (hover effect) when users interact with the components' rows.

**UI/UX Improvements:**

* Added `transition-colors` and `hover:bg-accent/5` classes to table/list rows in `EpisodeTable.vue`, `SeasonTable.vue`, `MoviePage.vue`, and `TranslationPage.vue` to provide a consistent hover highlight effect. [[1]](diffhunk://#diff-f73153f1e26a125dfa7b78fcff2ec2b3685feb0237f0fcfab56bd561a4488fdcL15-R15) [[2]](diffhunk://#diff-d102c802b0c7c18106e77617598401039974bf35e68792c87339f1a8044a7162L18-R19) [[3]](diffhunk://#diff-5e7a2ed98fe541d42283259f59842eff0b3b7bf2bb9b0962dc18d05ba4ec621cL75-R75) [[4]](diffhunk://#diff-72a46a2c5e371164b774094ed3a3d768741e6b2b26506992f9a95c327968eea2L62-R62)
* Updated conditional class logic in `SeasonTable.vue` to ensure the hover effect only applies when a season has episodes.