### PR TITLE
Fix Microsoft translator failures on long subtitle lines

### DIFF
--- a/Lingarr.Server.Tests/Services/Translation/TranslationTextChunkerTests.cs
+++ b/Lingarr.Server.Tests/Services/Translation/TranslationTextChunkerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using GTranslate;
+using GTranslate.Results;
+using GTranslate.Translators;
+using Lingarr.Core.Configuration;
+using Lingarr.Server.Interfaces.Services;
+using Lingarr.Server.Services;
+using Lingarr.Server.Services.Translation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Lingarr.Server.Tests.Services.Translation;
+
+public class TranslationTextChunkerTests
+{
+    [Fact]
+    public void Split_ShouldReturnOriginalText_WhenWithinLimit()
+    {
+        var text = "Short subtitle line";
+
+        var chunks = TranslationTextChunker.Split(text, 1000);
+
+        Assert.Single(chunks);
+        Assert.Equal(text, chunks[0]);
+    }
+
+    [Fact]
+    public void Split_ShouldPreferWhitespaceBoundary_WhenTextExceedsLimit()
+    {
+        var text = string.Join(" ", Enumerable.Repeat("word", 260));
+
+        var chunks = TranslationTextChunker.Split(text, 1000);
+
+        Assert.True(chunks.Count > 1);
+        Assert.All(chunks, chunk => Assert.True(chunk.Length <= 1000));
+        Assert.Equal(text, string.Join(" ", chunks));
+    }
+
+    [Fact]
+    public void Split_ShouldFallbackToHardCut_WhenNoWhitespaceExists()
+    {
+        var text = new string('a', 2100);
+
+        var chunks = TranslationTextChunker.Split(text, 1000);
+
+        Assert.Equal(3, chunks.Count);
+        Assert.All(chunks, chunk => Assert.True(chunk.Length <= 1000));
+        Assert.Equal(text, string.Concat(chunks));
+    }
+
+    [Fact]
+    public async Task GTranslatorService_ShouldSplitMicrosoftInput_AndRecombineTranslatedChunks()
+    {
+        var settings = new Dictionary<string, string>
+        {
+            { SettingKeys.Translation.MaxRetries, "0" },
+            { SettingKeys.Translation.RetryDelay, "0" },
+            { SettingKeys.Translation.RetryDelayMultiplier, "2" }
+        };
+
+        var settingsMock = new Mock<ISettingService>();
+        settingsMock.Setup(service => service.GetSettings(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(settings);
+
+        var translator = new MicrosoftTranslator();
+        var service = new GTranslatorService<MicrosoftTranslator>(
+            translator,
+            "/tmp/microsoft_languages.json",
+            settingsMock.Object,
+            NullLogger.Instance,
+            new LanguageCodeService(NullLogger<LanguageCodeService>.Instance));
+
+        var input = string.Join(" ", Enumerable.Repeat("word", 260));
+        var expectedChunks = TranslationTextChunker.Split(input, 1000);
+
+        var result = await service.TranslateAsync(
+            input,
+            "en",
+            "es",
+            null,
+            null,
+            CancellationToken.None);
+
+        Assert.Equal(input, result);
+        Assert.Equal(expectedChunks.Count, translator.ReceivedTexts.Count);
+        Assert.All(translator.ReceivedTexts, chunk => Assert.True(chunk.Length <= 1000));
+    }
+
+    private sealed class MicrosoftTranslator : ITranslator
+    {
+        public List<string> ReceivedTexts { get; } = [];
+
+        public string Name => nameof(MicrosoftTranslator);
+
+        public Task<ITranslationResult> TranslateAsync(string text, string toLanguage, string? fromLanguage = null)
+        {
+            ReceivedTexts.Add(text);
+            return Task.FromResult<ITranslationResult>(CreateResult(text, toLanguage, fromLanguage ?? "en"));
+        }
+
+        public Task<ITranslationResult> TranslateAsync(string text, ILanguage toLanguage, ILanguage? fromLanguage = null)
+        {
+            ReceivedTexts.Add(text);
+            return Task.FromResult<ITranslationResult>(CreateResult(text, toLanguage.ISO6391, fromLanguage?.ISO6391 ?? "en"));
+        }
+
+        public Task<ITransliterationResult> TransliterateAsync(string text, string toLanguage, string? fromLanguage = null)
+            => throw new NotImplementedException();
+
+        public Task<ITransliterationResult> TransliterateAsync(string text, ILanguage toLanguage, ILanguage? fromLanguage = null)
+            => throw new NotImplementedException();
+
+        public Task<ILanguage> DetectLanguageAsync(string text)
+            => throw new NotImplementedException();
+
+        public bool IsLanguageSupported(string language) => true;
+
+        public bool IsLanguageSupported(ILanguage language) => true;
+
+        private static ITranslationResult CreateResult(string text, string toLanguage, string fromLanguage)
+        {
+            var targetLanguage = Language.GetLanguage(toLanguage);
+            var sourceLanguage = Language.GetLanguage(fromLanguage);
+
+            var result = (MicrosoftTranslationResult)Activator.CreateInstance(
+                typeof(MicrosoftTranslationResult),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                args: [text, text, targetLanguage, sourceLanguage, 1f],
+                culture: null)!;
+
+            return result;
+        }
+    }
+}

--- a/Lingarr.Server/Services/Translation/GTranslatorService.cs
+++ b/Lingarr.Server/Services/Translation/GTranslatorService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using GTranslate.Translators;
 using Lingarr.Core.Configuration;
@@ -9,6 +10,7 @@ namespace Lingarr.Server.Services.Translation;
 
 public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
 {
+    private const int MicrosoftTranslatorMaxCharacters = 1000;
     private readonly T _translator;
     private bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
@@ -78,9 +80,37 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
     {
         await InitializeAsync();
 
-        using var retry = new CancellationTokenSource();
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, retry.Token);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
+        var segments = GetTranslationSegments(text);
+        if (segments.Count > 1)
+        {
+            _logger.LogWarning(
+                "Splitting Microsoft Translator input into {SegmentCount} chunks because the line length {Length} exceeds the {Limit}-character limit.",
+                segments.Count,
+                text.Length,
+                MicrosoftTranslatorMaxCharacters);
+        }
+
+        var translatedSegments = new List<string>(segments.Count);
+        foreach (var segment in segments)
+        {
+            translatedSegments.Add(await TranslateSegmentAsync(
+                segment,
+                sourceLanguage,
+                targetLanguage,
+                linked.Token));
+        }
+
+        return string.Join(" ", translatedSegments.Where(segment => !string.IsNullOrWhiteSpace(segment)));
+    }
+
+    private async Task<string> TranslateSegmentAsync(
+        string text,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken)
+    {
         var delay = _retryDelay;
         for (var attempt = 1; attempt <= _maxRetries + 1; attempt++)
         {
@@ -90,7 +120,7 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
                         text,
                         targetLanguage,
                         sourceLanguage)
-                    .WaitAsync(linked.Token)
+                    .WaitAsync(cancellationToken)
                     .ConfigureAwait(false);
 
                 return result.Translation;
@@ -107,7 +137,7 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
                     "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
                     "GTranslator", ex.StatusCode, delay, attempt, _maxRetries);
 
-                await Task.Delay(delay, linked.Token).ConfigureAwait(false);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -122,5 +152,21 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
         }
 
         throw new TranslationException("Translation failed after maximum retry attempts.");
+    }
+
+    private static List<string> GetTranslationSegments(string text)
+    {
+        if (!IsMicrosoftTranslator() || text.Length <= MicrosoftTranslatorMaxCharacters)
+        {
+            return [text];
+        }
+
+        return TranslationTextChunker.Split(text, MicrosoftTranslatorMaxCharacters);
+    }
+
+    private static bool IsMicrosoftTranslator()
+    {
+        return typeof(T) == typeof(MicrosoftTranslator) ||
+               typeof(T).Name == nameof(MicrosoftTranslator);
     }
 }

--- a/Lingarr.Server/Services/Translation/TranslationTextChunker.cs
+++ b/Lingarr.Server/Services/Translation/TranslationTextChunker.cs
@@ -1,0 +1,59 @@
+namespace Lingarr.Server.Services.Translation;
+
+public static class TranslationTextChunker
+{
+    public static List<string> Split(string text, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        if (maxLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxLength), "Maximum length must be positive.");
+        }
+
+        if (text.Length <= maxLength)
+        {
+            return [text];
+        }
+
+        var chunks = new List<string>();
+        var remaining = text.Trim();
+
+        while (remaining.Length > maxLength)
+        {
+            var splitIndex = FindSplitIndex(remaining, maxLength);
+            var chunk = remaining[..splitIndex].TrimEnd();
+
+            if (!string.IsNullOrWhiteSpace(chunk))
+            {
+                chunks.Add(chunk);
+            }
+
+            remaining = remaining[splitIndex..].TrimStart();
+        }
+
+        if (!string.IsNullOrWhiteSpace(remaining))
+        {
+            chunks.Add(remaining.Trim());
+        }
+
+        return chunks;
+    }
+
+    private static int FindSplitIndex(string text, int maxLength)
+    {
+        var upperBound = Math.Min(maxLength, text.Length);
+        for (var index = upperBound; index > 0; index--)
+        {
+            if (char.IsWhiteSpace(text[index - 1]))
+            {
+                return index;
+            }
+        }
+
+        return upperBound;
+    }
+}


### PR DESCRIPTION
## Summary
- split oversized Microsoft Translator inputs into <=1000 character chunks before calling GTranslate
- preserve the existing retry behavior per chunk and recombine the translated output
- add regression tests for chunk splitting and the Microsoft translator path

## Why
Microsoft Translator rejects oversized subtitle payloads, which leaves Lingarr repeatedly retrying subtitle lines that can never succeed. This change keeps Microsoft usable for long formatted subtitle lines instead of failing the whole request.

## Testing
- DOTNET_ROLL_FORWARD=Major dotnet test Lingarr.Server.Tests/Lingarr.Server.Tests.csproj --filter TranslationTextChunkerTests --no-restore