### PR TITLE
fix: dedupe content-path + ExecuteUpdateAsync in catch (refs #339)

### DIFF
--- a/Lingarr.Server/Services/TranslationRequestService.cs
+++ b/Lingarr.Server/Services/TranslationRequestService.cs
@@ -542,6 +542,27 @@ public class TranslationRequestService : ITranslationRequestService
                 serviceType
             );
 
+            // Skip if an active content-translation row for this media+target already exists.
+            var existingId = await _dbContext.TranslationRequests
+                .Where(r => r.MediaId == translationRequest.MediaId
+                         && r.MediaType == translationRequest.MediaType
+                         && r.Title == translationRequest.Title
+                         && r.SourceLanguage == translationRequest.SourceLanguage
+                         && r.TargetLanguage == translationRequest.TargetLanguage
+                         && (r.Status == TranslationStatus.Pending || r.Status == TranslationStatus.InProgress))
+                .Select(r => (int?)r.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (existingId != null)
+            {
+                _logger.LogInformation(
+                    "Duplicate content-translation request skipped for mediaId {MediaId} ({MediaType}) '{Title}' {Src}->{Tgt} (existing id {Id}).",
+                    translationRequest.MediaId, translationRequest.MediaType,
+                    translationRequest.Title,
+                    translationRequest.SourceLanguage, translationRequest.TargetLanguage, existingId.Value);
+                return Array.Empty<BatchTranslatedLine>();
+            }
+
             // Add TranslationRequest
             _dbContext.TranslationRequests.Add(translationRequest);
             await _dbContext.SaveChangesAsync(cancellationToken);
@@ -679,10 +700,18 @@ public class TranslationRequestService : ITranslationRequestService
         }
         catch (TaskCanceledException ex)
         {
-            translationRequest.CompletedAt = DateTime.UtcNow;
+            // ExecuteUpdateAsync bypasses change-tracking so a concurrent write cannot abort this save.
+            var now = DateTime.UtcNow;
+            await _dbContext.TranslationRequests
+                .Where(r => r.Id == translationRequest.Id)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.Status, TranslationStatus.Cancelled)
+                    .SetProperty(r => r.ErrorMessage, ex.Message)
+                    .SetProperty(r => r.CompletedAt, (DateTime?)now)
+                    .SetProperty(r => r.UpdatedAt, now));
+            translationRequest.CompletedAt = now;
             translationRequest.Status = TranslationStatus.Cancelled;
             translationRequest.ErrorMessage = ex.Message;
-            await _dbContext.SaveChangesAsync();
             await _eventService.LogEvent(translationRequest.Id, TranslationStatus.Cancelled, ex.Message);
             await UpdateActiveCount();
             await _progressService.Emit(translationRequest, 0);
@@ -691,11 +720,19 @@ public class TranslationRequestService : ITranslationRequestService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error translating subtitle content");
-            translationRequest.CompletedAt = DateTime.UtcNow;
+            var now = DateTime.UtcNow;
+            await _dbContext.TranslationRequests
+                .Where(r => r.Id == translationRequest.Id)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.Status, TranslationStatus.Failed)
+                    .SetProperty(r => r.ErrorMessage, ex.Message)
+                    .SetProperty(r => r.StackTrace, ex.ToString())
+                    .SetProperty(r => r.CompletedAt, (DateTime?)now)
+                    .SetProperty(r => r.UpdatedAt, now));
+            translationRequest.CompletedAt = now;
             translationRequest.Status = TranslationStatus.Failed;
             translationRequest.ErrorMessage = ex.Message;
             translationRequest.StackTrace = ex.ToString();
-            await _dbContext.SaveChangesAsync();
             await _eventService.LogEvent(translationRequest.Id, TranslationStatus.Failed, ex.Message);
             await UpdateActiveCount();
             await _progressService.Emit(translationRequest, 0);
@@ -737,9 +774,15 @@ public class TranslationRequestService : ITranslationRequestService
     {
         await _statisticsService.UpdateTranslationStatisticsFromLines(translationRequest, serviceType, translationService.ModelName, results);
 
-        translationRequest.CompletedAt = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
+        await _dbContext.TranslationRequests
+            .Where(r => r.Id == translationRequest.Id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(r => r.Status, TranslationStatus.Completed)
+                .SetProperty(r => r.CompletedAt, (DateTime?)now)
+                .SetProperty(r => r.UpdatedAt, now), cancellationToken);
+        translationRequest.CompletedAt = now;
         translationRequest.Status = TranslationStatus.Completed;
-        await _dbContext.SaveChangesAsync(cancellationToken);
         await _eventService.LogEvent(translationRequest.Id, TranslationStatus.Completed);
         await UpdateActiveCount();
         await _progressService.Emit(translationRequest, 100); // Tells the frontend to update translation request to a finished state


### PR DESCRIPTION
Fixes #339

## Problem

On 1.0.9 the zombie `translation_requests` rows reported in #339 still appear whenever Bazarr is used as a translator client. The 1.0.9 dedupe guard added in 75190e4 lives in `EnqueueRequest`, which is only reached from `CreateRequest` → `/api/translate/file`. Bazarr's `translator_type: lingarr` (see upstream [`bazarr/subtitles/tools/translate/services/lingarr_translator.py`](https://github.com/morpheus65535/bazarr/blob/master/bazarr/subtitles/tools/translate/services/lingarr_translator.py)) does not hit that endpoint — it `POST`s to `/api/translate/content`, which routes through `TranslateContentAsync` and inserts the row directly. So the dedupe never fires for the Bazarr path.

On top of that, when `TranslateContentAsync` hits an exception, its `catch` blocks load the tracked entity, flip its `Status`, and call `SaveChangesAsync`. This races with other DbContext instances that may have modified or deleted the same row in the meantime (e.g. `RemoveTranslationRequest` from the UI, or the automation worker), and produces:

```
Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException:
  The database operation was expected to affect 1 row(s), but actually affected 0 row(s);
  data may have been modified or deleted since entities were loaded.
    at TranslationRequestService.TranslateContentAsync(...)
```

The exception aborts the catch block before it persists the status update, so the row stays at `InProgress` forever. Every new Bazarr tick adds more of these. We accumulated ~46 rows stuck at `status=1, job_id=NULL, subtitle_to_translate=''` in ~24h.

## Our repro vs #339's OP (webysther)

The triggering client on our side is **[`bazarr-autotranslate`](https://github.com/zelak312/bazarr_autotranslate)** (repo: https://github.com/zelak312/bazarr_autotranslate, image `ghcr.io/zelak312/bazarr_autotranslate:latest`). It's a small Python scheduler that loops over Bazarr's wanted-subtitle list on an interval and fires translation requests at Bazarr for each one where a base-language source exists and the target is missing. Bazarr, configured with `translator_type: lingarr`, then POSTs to Lingarr's `/api/translate/content`. This gives us a predictable, repeating load on the content path that the #339 OP's manual UI trigger couldn't hit consistently.

| | #339 OP (webysther) | Us |
|---|---|---|
| Triggering client | Bazarr UI, manual click | [zelak312/bazarr_autotranslate](https://github.com/zelak312/bazarr_autotranslate) deployed as a k3s Deployment, `INTERVAL_BETWEEN_SCANS=3600` |
| Bazarr → Lingarr path | `translator_type: lingarr` → POST `/api/translate/content` | same |
| Lingarr host | Docker Compose on Ubuntu 24.04 VM on Proxmox | TrueNAS SCALE custom app (Docker via containerd) |
| Backend model/endpoint | Ollama via Open-WebUI, OpenAI-compat | Ollama native on TrueNAS, OpenAI-compat (`/v1/chat/completions`), `aya-expanse:8b` |
| Lingarr version | 1.0.8 then 1.0.9 | 1.0.9 |
| Duplicate rows | 2–3 concurrent, sometimes more 30 min later | 2 per scan tick (hourly), growing indefinitely |
| DB sink | SQLite (default) | SQLite (default) |

We also captured the exact `DbUpdateConcurrencyException` stack trace live out of `/api/logs/stream`, which may help since the maintainer noted they couldn't reproduce in March.

Key differences from the OP worth noting:
- Our traffic is automated and repetitive (bazarr-autotranslate runs on a cron), so the race window is consistently hit. One-shot manual UI triggers like the OP's are harder to repro but hit the same code path.
- We confirmed the DB row stays at `InProgress` while the catch block throws `DbUpdateConcurrencyException` — the OP's screenshots show the same "stuck" symptom but didn't include the stack trace.

## Fix

`Lingarr.Server/Services/TranslationRequestService.cs` — three changes:

1. **Dedupe guard at the top of `TranslateContentAsync`**, mirroring the 1.0.9 pattern from `EnqueueRequest`, matching on `MediaId + MediaType + Title + SourceLanguage + TargetLanguage` with `Status ∈ {Pending, InProgress}`. If an active row exists, log it and return `Array.Empty<BatchTranslatedLine>()`. Bazarr's translator treats an empty response as "no lines translated this pass" per its retry decorator — the prior in-flight request continues normally.

2. **`ExecuteUpdateAsync` in both `catch` blocks** (`TaskCanceledException` and generic `Exception`). One atomic SQL `UPDATE` scoped by `Id`, bypasses change-tracking, tolerates missing or concurrently mutated rows. Still updates the in-memory `translationRequest` afterwards so `_progressService.Emit` downstream sees a consistent final state. No more `DbUpdateConcurrencyException` killing the status update.

3. **Same pattern in `HandleAsyncTranslationCompletion`** for the success path, for the same race-hardening reason.

No schema change, no migration, frontend untouched. EF Core 9 (already in this repo) supports `ExecuteUpdateAsync`.

## Validation

Deployed the patched image (`ghcr.io/spyrospsarras/lingarr:fix-zombie-concurrency-exec-update`) on our TrueNAS install.

Before fix (last 24h pre-deploy):
- ~46 rows stuck at `status=1, job_id=NULL, subtitle_to_translate=''` — growing by ~2 per hourly Bazarr scan.
- `DbUpdateConcurrencyException` on every failure path in the log stream.

After fix (first hour post-deploy, 118 requests generated by Bazarr):
- All 118 settled to `status=3 Failed` (the failures themselves are unrelated — Ollama occasionally rejects payloads as `"messages is too short"` when Lingarr filters every line of a subtitle block; different bug, worth filing separately).
- **0** rows stuck at `status=1` past the Bazarr retry window.
- **0** `DbUpdateConcurrencyException` in logs.
- **0** duplicate `(Title, TargetLanguage)` rows in active state at any point.

Happy to iterate on the patch shape if you'd prefer a different fallback response for the dedupe case (e.g. 409 instead of empty array), or tighter/looser match criteria.