### PR TITLE
feat: dedupe identical translations per file

### DIFF
--- a/Lingarr.Server.Tests/Services/SubtitleTranslationServiceTests.cs
+++ b/Lingarr.Server.Tests/Services/SubtitleTranslationServiceTests.cs
@@ -270,6 +270,116 @@ public class SubtitleTranslationServiceTests
         Assert.Equal(1, translatedCalls);
     }
 
+    // ===== Per-file dedup =====
+    // Many fansub .ass files stack multiple Dialogue lines at the same timestamp
+    // with byte-identical plaintext (shadow/glow/border/main rendered as separate
+    // entries). The service caches by (StartTime, EndTime, plaintext) and reuses
+    // the translation for the duplicates.
+
+    [Fact]
+    public async Task TranslateSubtitles_StackedDuplicates_TranslatesOnceAndReusesResult()
+    {
+        // Arrange - four entries with the same (Start, End, plaintext): the layered shadow/glow/border/main case
+        var captured = new List<string>();
+        var harness = CreatePerLineHarness(text => { captured.Add(text); return "hola"; });
+        var subtitles = new List<SubtitleItem>
+        {
+            new() { Position = 1, StartTime = 1000, EndTime = 2000, Lines = ["Hello"], PlaintextLines = ["Hello"] },
+            new() { Position = 2, StartTime = 1000, EndTime = 2000, Lines = ["Hello"], PlaintextLines = ["Hello"] },
+            new() { Position = 3, StartTime = 1000, EndTime = 2000, Lines = ["Hello"], PlaintextLines = ["Hello"] },
+            new() { Position = 4, StartTime = 1000, EndTime = 2000, Lines = ["Hello"], PlaintextLines = ["Hello"] }
+        };
+
+        // Act
+        await harness.Service.TranslateSubtitles(subtitles, NewRequest(),
+            stripSubtitleFormatting: false,
+            preserveLineBreaks: false,
+            contextBefore: 0,
+            contextAfter: 0,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(captured);
+        Assert.All(subtitles, s => Assert.Equal(["hola"], s.TranslatedLines));
+    }
+
+    [Fact]
+    public async Task TranslateSubtitles_SameTextDifferentTimes_TranslatesEachIndependently()
+    {
+        // Arrange - same plaintext at different timestamps are different scenes; each must be translated
+        var captured = new List<string>();
+        var harness = CreatePerLineHarness(text => { captured.Add(text); return "si"; });
+        var subtitles = new List<SubtitleItem>
+        {
+            new() { Position = 1, StartTime = 1000, EndTime = 2000, Lines = ["Yes"], PlaintextLines = ["Yes"] },
+            new() { Position = 2, StartTime = 5000, EndTime = 6000, Lines = ["Yes"], PlaintextLines = ["Yes"] },
+            new() { Position = 3, StartTime = 9000, EndTime = 10000, Lines = ["Yes"], PlaintextLines = ["Yes"] }
+        };
+
+        // Act
+        await harness.Service.TranslateSubtitles(subtitles, NewRequest(),
+            stripSubtitleFormatting: false,
+            preserveLineBreaks: false,
+            contextBefore: 0,
+            contextAfter: 0,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(3, captured.Count);
+    }
+
+    [Fact]
+    public async Task TranslateSubtitles_NoDuplicates_TranslatesEvery()
+    {
+        // Arrange - SRT/VTT typical case: every entry unique
+        var captured = new List<string>();
+        var harness = CreatePerLineHarness(text => { captured.Add(text); return $"tr:{text}"; });
+        var subtitles = new List<SubtitleItem>
+        {
+            new() { Position = 1, StartTime = 1000, EndTime = 2000, Lines = ["Hello"], PlaintextLines = ["Hello"] },
+            new() { Position = 2, StartTime = 3000, EndTime = 4000, Lines = ["World"], PlaintextLines = ["World"] },
+            new() { Position = 3, StartTime = 5000, EndTime = 6000, Lines = ["How are you?"], PlaintextLines = ["How are you?"] }
+        };
+
+        // Act
+        await harness.Service.TranslateSubtitles(subtitles, NewRequest(),
+            stripSubtitleFormatting: false,
+            preserveLineBreaks: false,
+            contextBefore: 0,
+            contextAfter: 0,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(["Hello", "World", "How are you?"], captured);
+        Assert.Equal(["tr:Hello"], subtitles[0].TranslatedLines);
+        Assert.Equal(["tr:World"], subtitles[1].TranslatedLines);
+        Assert.Equal(["tr:How are you?"], subtitles[2].TranslatedLines);
+    }
+
+    [Fact]
+    public async Task TranslateSubtitles_SameTimestampDifferentText_TranslatesEachIndependently()
+    {
+        // Arrange - overlapping dual-speaker dialogue: same timestamp, different text — both translated
+        var captured = new List<string>();
+        var harness = CreatePerLineHarness(text => { captured.Add(text); return $"tr:{text}"; });
+        var subtitles = new List<SubtitleItem>
+        {
+            new() { Position = 1, StartTime = 1000, EndTime = 2000, Lines = ["Run!"], PlaintextLines = ["Run!"] },
+            new() { Position = 2, StartTime = 1000, EndTime = 2000, Lines = ["Watch out!"], PlaintextLines = ["Watch out!"] }
+        };
+
+        // Act
+        await harness.Service.TranslateSubtitles(subtitles, NewRequest(),
+            stripSubtitleFormatting: false,
+            preserveLineBreaks: false,
+            contextBefore: 0,
+            contextAfter: 0,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(["Run!", "Watch out!"], captured);
+    }
+
     #endregion
 
     #region ProcessSubtitleBatch Tests

--- a/Lingarr.Server/Services/SubtitleTranslationService.cs
+++ b/Lingarr.Server/Services/SubtitleTranslationService.cs
@@ -55,6 +55,13 @@ public class SubtitleTranslationService
         var iteration = 0;
         var totalSubtitles = subtitles.Count;
 
+        // Many fansub .ass files stack multiple Dialogue lines at the same
+        // timestamp with identical plaintext (shadow, glow, border, main
+        // layers). Translate each unique (Start, End, plaintext) once per
+        // file and reuse the result for the rest. SRT/VTT files almost never
+        // share timestamps, so this is a no-op there.
+        var translationCache = new Dictionary<string, string>();
+
         for (var index = 0; index < totalSubtitles; index++)
         {
             var subtitle = subtitles[index];
@@ -82,14 +89,20 @@ public class SubtitleTranslationService
                     continue;
                 }
 
-                translatedLines.Add(await TranslateSubtitleLine(new TranslateAbleSubtitleLine
+                var cacheKey = $"{subtitle.StartTime}|{subtitle.EndTime}|{subtitleLine}";
+                if (!translationCache.TryGetValue(cacheKey, out var translated))
                 {
-                    SubtitleLine = subtitleLine,
-                    SourceLanguage = translationRequest.SourceLanguage,
-                    TargetLanguage = translationRequest.TargetLanguage,
-                    ContextLinesBefore = contextLinesBefore.Count > 0 ? contextLinesBefore : null,
-                    ContextLinesAfter = contextLinesAfter.Count > 0 ? contextLinesAfter : null
-                }, cancellationToken));
+                    translated = await TranslateSubtitleLine(new TranslateAbleSubtitleLine
+                    {
+                        SubtitleLine = subtitleLine,
+                        SourceLanguage = translationRequest.SourceLanguage,
+                        TargetLanguage = translationRequest.TargetLanguage,
+                        ContextLinesBefore = contextLinesBefore.Count > 0 ? contextLinesBefore : null,
+                        ContextLinesAfter = contextLinesAfter.Count > 0 ? contextLinesAfter : null
+                    }, cancellationToken);
+                    translationCache[cacheKey] = translated;
+                }
+                translatedLines.Add(translated);
             }
 
             subtitle.TranslatedLines = translatedLines.Count > 1


### PR DESCRIPTION
## Summary

Follow-up to #375 (as discussed there). Per-file translation cache so stacked ASS Dialogue layers (shadow/glow/border/main) translate once instead of N times. SRT/VTT entries don't share timestamps, so this is a no-op for those formats.

## What changed

- `SubtitleTranslationService.TranslateSubtitles`: per-call `Dictionary<string, string>` keyed on `{StartTime}|{EndTime}|{subtitleLine}`. Cache hit → reuse the translation, skip the LLM call. Cache miss → translate, store, use.
- Cache lives inside the method — never shared across files.
- Plays correctly with the per-line iteration introduced in #406: each `subtitleLine` is cached individually, so `preserveLineBreaks` is unaffected.

## On the dual-speaker concern from #375

The cache only collapses the LLM call, not the subtitle entries. Each `SubtitleItem` still gets its own `TranslatedLines` assignment, so dual-speaker overlap with shared text produces two output entries — same translation for both, which is the same outcome as translating each independently from a deterministic model.

## Measured impact (real library files)

| File | Non-empty lines | Unique keys | Saved | % |
|------|-----------------|-------------|-------|---|
| Blood Blockade Battlefront S01E11 | 223 | 138 | 85 | 38.1% |
| The Devil Is a Part-Timer S02E02 | 4270 | 2867 | 1403 | 32.9% |
| Date A Live S04E08 | 82 | 75 | 7 | 8.5% |

Top duplicate patterns: opening-theme lyrics (shadow/main pair), animated typography signs (per-letter Dialogue lines), episode titles.

## Tests

- `TranslateSubtitles_StackedDuplicates_TranslatesOnceAndReusesResult`
- `TranslateSubtitles_SameTextDifferentTimes_TranslatesEachIndependently`
- `TranslateSubtitles_NoDuplicates_TranslatesEvery`
- `TranslateSubtitles_SameTimestampDifferentText_TranslatesEachIndependently`

181 server tests passing.

## AI disclosure

LLM-assisted; reviewed and tested locally against the files in the impact table.