### PR TITLE
fix: apply request_timeout to GTranslate HTTP clients

### DIFF
--- a/Lingarr.Server/Services/Translation/GTranslatorService.cs
+++ b/Lingarr.Server/Services/Translation/GTranslatorService.cs
@@ -61,7 +61,7 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
                 ? multiplier
                 : 2;
 
-            var requestTimeoutMinutes = int.TryParse(settings[SettingKeys.Translation.RequestTimeout], out var requestTimeout)
+            var requestTimeoutMinutes = int.TryParse(settings[SettingKeys.Translation.RequestTimeout], out var requestTimeout) && requestTimeout > 0
                 ? requestTimeout
                 : 5;
             ApplyHttpClientTimeout(TimeSpan.FromMinutes(requestTimeoutMinutes));

--- a/Lingarr.Server/Services/Translation/GTranslatorService.cs
+++ b/Lingarr.Server/Services/Translation/GTranslatorService.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using GTranslate.Translators;
 using Lingarr.Core.Configuration;
 using Lingarr.Server.Exceptions;
@@ -43,7 +44,8 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
             var settings = await _settings.GetSettings([
                 SettingKeys.Translation.MaxRetries,
                 SettingKeys.Translation.RetryDelay,
-                SettingKeys.Translation.RetryDelayMultiplier
+                SettingKeys.Translation.RetryDelayMultiplier,
+                SettingKeys.Translation.RequestTimeout
             ]);
 
             _maxRetries = int.TryParse(settings[SettingKeys.Translation.MaxRetries], out var maxRetries)
@@ -58,6 +60,11 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
             _retryDelayMultiplier = int.TryParse(settings[SettingKeys.Translation.RetryDelayMultiplier], out var multiplier)
                 ? multiplier
                 : 2;
+
+            var requestTimeoutMinutes = int.TryParse(settings[SettingKeys.Translation.RequestTimeout], out var requestTimeout)
+                ? requestTimeout
+                : 5;
+            ApplyHttpClientTimeout(TimeSpan.FromMinutes(requestTimeoutMinutes));
 
             _initialized = true;
         }
@@ -122,5 +129,40 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
         }
 
         throw new TranslationException("Translation failed after maximum retry attempts.");
+    }
+
+    private void ApplyHttpClientTimeout(TimeSpan timeout)
+    {
+        var httpClient = GetTranslatorHttpClient();
+        if (httpClient is null)
+        {
+            _logger.LogWarning(
+                "Unable to locate an HttpClient instance on {TranslatorType}; request timeout setting will not be applied.",
+                typeof(T).Name);
+            return;
+        }
+
+        httpClient.Timeout = timeout;
+    }
+
+    private HttpClient? GetTranslatorHttpClient()
+    {
+        var translatorType = _translator.GetType();
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        foreach (var field in translatorType.GetFields(flags))
+        {
+            if (field.FieldType != typeof(HttpClient))
+            {
+                continue;
+            }
+
+            return field.GetValue(_translator) as HttpClient;
+        }
+
+        var property = translatorType.GetProperties(flags)
+            .FirstOrDefault(p => p.PropertyType == typeof(HttpClient) && p.CanRead);
+
+        return property?.GetValue(_translator) as HttpClient;
     }
 }


### PR DESCRIPTION
## Summary
- Applies Lingarr's `request_timeout` setting to the underlying `HttpClient` used by all GTranslate-backed services (Google, Bing, Microsoft, Yandex).
- Uses the existing translator wrapper to locate the injected `HttpClient` and set its timeout in minutes.

## Why
This fixes issue #421 where Microsoft Translator requests could hang until the GTranslate `HttpClient` hit its default 100 second timeout instead of Lingarr's configured timeout.

## Verification
- `git diff --check`
- Local `dotnet build` could not be run here because `dotnet` is not installed in this environment.

Closes #421
