### PR TITLE
fix: build GTranslate clients from IHttpClientFactory

### DIFF
--- a/Lingarr.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/Lingarr.Server/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using GTranslate.Translators;
 using Hangfire;
 using Hangfire.MySql;
 using Hangfire.PostgreSql;
@@ -176,10 +175,6 @@ public static class ServiceCollectionExtensions
         builder.Services.AddHostedService<StartupService>();
 
         // Add translation services
-        builder.Services.AddTransient<GoogleTranslator>();
-        builder.Services.AddTransient<BingTranslator>();
-        builder.Services.AddTransient<MicrosoftTranslator>();
-        builder.Services.AddTransient<YandexTranslator>();
         builder.Services.AddTransient<OpenAiService>();
 
         builder.Services.AddTransient<PathConversionService>();

--- a/Lingarr.Server/Services/Translation/GTranslatorService.cs
+++ b/Lingarr.Server/Services/Translation/GTranslatorService.cs
@@ -4,12 +4,15 @@ using Lingarr.Core.Configuration;
 using Lingarr.Server.Exceptions;
 using Lingarr.Server.Interfaces.Services;
 using Lingarr.Server.Services.Translation.Base;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Lingarr.Server.Services.Translation;
 
 public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
 {
-    private readonly T _translator;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private T? _translator;
     private bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
@@ -22,13 +25,15 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
     public override string? ModelName => null;
 
     public GTranslatorService(
-        T translator,
+        IServiceProvider serviceProvider,
+        IHttpClientFactory httpClientFactory,
         string languageFilePath,
         ISettingService settings,
         ILogger logger,
         LanguageCodeService languageCodeService) : base(settings, logger, languageCodeService, languageFilePath)
     {
-        _translator = translator;
+        _serviceProvider = serviceProvider;
+        _httpClientFactory = httpClientFactory;
     }
 
     private async Task InitializeAsync()
@@ -43,7 +48,8 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
             var settings = await _settings.GetSettings([
                 SettingKeys.Translation.MaxRetries,
                 SettingKeys.Translation.RetryDelay,
-                SettingKeys.Translation.RetryDelayMultiplier
+                SettingKeys.Translation.RetryDelayMultiplier,
+                SettingKeys.Translation.RequestTimeout
             ]);
 
             _maxRetries = int.TryParse(settings[SettingKeys.Translation.MaxRetries], out var maxRetries)
@@ -58,6 +64,15 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
             _retryDelayMultiplier = int.TryParse(settings[SettingKeys.Translation.RetryDelayMultiplier], out var multiplier)
                 ? multiplier
                 : 2;
+
+            var requestTimeoutMinutes = int.TryParse(settings[SettingKeys.Translation.RequestTimeout], out var requestTimeout) && requestTimeout > 0
+                ? requestTimeout
+                : 5;
+
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromMinutes(requestTimeoutMinutes);
+
+            _translator ??= ActivatorUtilities.CreateInstance<T>(_serviceProvider, httpClient);
 
             _initialized = true;
         }
@@ -86,7 +101,7 @@ public class GTranslatorService<T> : BaseLanguageService where T : ITranslator
         {
             try
             {
-                var result = await _translator.TranslateAsync(
+                var result = await _translator!.TranslateAsync(
                         text,
                         targetLanguage,
                         sourceLanguage)

--- a/Lingarr.Server/Services/Translation/TranslationFactory.cs
+++ b/Lingarr.Server/Services/Translation/TranslationFactory.cs
@@ -29,7 +29,8 @@ public class TranslationFactory : ITranslationServiceFactory
                 languageCodeService),
 
             "google" => new GTranslatorService<GoogleTranslator>(
-                _serviceProvider.GetRequiredService<GoogleTranslator>(),
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<IHttpClientFactory>(),
                 "/app/Statics/google_languages.json",
                 _serviceProvider.GetRequiredService<ISettingService>(),
                 _serviceProvider.GetRequiredService<ILogger<GoogleTranslator>>(),
@@ -37,7 +38,8 @@ public class TranslationFactory : ITranslationServiceFactory
             ),
 
             "bing" => new GTranslatorService<BingTranslator>(
-                _serviceProvider.GetRequiredService<BingTranslator>(),
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<IHttpClientFactory>(),
                 "/app/Statics/bing_languages.json",
                 _serviceProvider.GetRequiredService<ISettingService>(),
                 _serviceProvider.GetRequiredService<ILogger<BingTranslator>>(),
@@ -45,7 +47,8 @@ public class TranslationFactory : ITranslationServiceFactory
             ),
 
             "microsoft" => new GTranslatorService<MicrosoftTranslator>(
-                _serviceProvider.GetRequiredService<MicrosoftTranslator>(),
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<IHttpClientFactory>(),
                 "/app/Statics/microsoft_languages.json",
                 _serviceProvider.GetRequiredService<ISettingService>(),
                 _serviceProvider.GetRequiredService<ILogger<MicrosoftTranslator>>(),
@@ -53,7 +56,8 @@ public class TranslationFactory : ITranslationServiceFactory
             ),
 
             "yandex" => new GTranslatorService<YandexTranslator>(
-                _serviceProvider.GetRequiredService<YandexTranslator>(),
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<IHttpClientFactory>(),
                 "/app/Statics/yandex_languages.json",
                 _serviceProvider.GetRequiredService<ISettingService>(),
                 _serviceProvider.GetRequiredService<ILogger<YandexTranslator>>(),


### PR DESCRIPTION
## Summary
- Build each GTranslate translator from `IHttpClientFactory` inside `GTranslatorService.InitializeAsync`
- Apply Lingarr's `request_timeout` directly to the `HttpClient` before constructing the translator
- Remove the now-unnecessary transient translator registrations from DI

## Why
This follows Rowan's suggestion in PR #425 and avoids brittle reflection against private fields on the translator classes.

## Verification
- `git diff --check`
- `dotnet build` could not be run here because `dotnet` is not installed in this environment

Related: #425
