### PR TITLE
fix: prevent sqlite settings lock failures

### DIFF
--- a/Lingarr.Core/Configuration/DatabaseConfiguration.cs
+++ b/Lingarr.Core/Configuration/DatabaseConfiguration.cs
@@ -72,6 +72,11 @@ public static class DatabaseConfiguration
     private static string GetSqliteConnectionString()
     {
         var sqliteDbPath = Environment.GetEnvironmentVariable("SQLITE_DB_PATH") ?? "local.db";
+        if (Path.IsPathRooted(sqliteDbPath))
+        {
+            return $"Data Source={sqliteDbPath};Foreign Keys=True";
+        }
+
         return $"Data Source=/app/config/{sqliteDbPath};Foreign Keys=True";
     }
 
@@ -117,6 +122,7 @@ public static class DatabaseConfiguration
 
         options.UseSqlite(connectionString,
                 sqliteOptions => sqliteOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
+            .AddInterceptors(new SqlitePragmaConnectionInterceptor())
             .UseSnakeCaseNamingConvention();
     }
 

--- a/Lingarr.Core/Configuration/SqlitePragmaConnectionInterceptor.cs
+++ b/Lingarr.Core/Configuration/SqlitePragmaConnectionInterceptor.cs
@@ -1,0 +1,44 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Lingarr.Core.Configuration;
+
+public sealed class SqlitePragmaConnectionInterceptor : DbConnectionInterceptor
+{
+    private const int BusyTimeoutMilliseconds = 120000;
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        ApplyPragmas(connection);
+        base.ConnectionOpened(connection, eventData);
+    }
+
+    public override async Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        ApplyPragmas(connection);
+        await base.ConnectionOpenedAsync(connection, eventData, cancellationToken);
+    }
+
+    private static void ApplyPragmas(DbConnection connection)
+    {
+        if (connection is not SqliteConnection)
+        {
+            return;
+        }
+
+        using var command = connection.CreateCommand();
+
+        command.CommandText = "PRAGMA journal_mode=WAL";
+        command.ExecuteScalar();
+
+        command.CommandText = $"PRAGMA busy_timeout={BusyTimeoutMilliseconds}";
+        command.ExecuteNonQuery();
+
+        command.CommandText = "PRAGMA synchronous=NORMAL";
+        command.ExecuteNonQuery();
+    }
+}

--- a/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
+++ b/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using Lingarr.Core.Configuration;
 using Lingarr.Core.Data;

--- a/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
+++ b/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Lingarr.Core.Configuration;
 using Lingarr.Core.Data;
 using Microsoft.Data.Sqlite;

--- a/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
+++ b/Lingarr.Server.Tests/Configuration/DatabaseConfigurationTests.cs
@@ -1,0 +1,57 @@
+using Lingarr.Core.Configuration;
+using Lingarr.Core.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Lingarr.Server.Tests.Configuration;
+
+public class DatabaseConfigurationTests
+{
+    [Fact]
+    public async Task ConfigureDbContext_Sqlite_EnablesWalAndBusyTimeout()
+    {
+        var originalSqliteDbPath = Environment.GetEnvironmentVariable("SQLITE_DB_PATH");
+        var dbPath = Path.Combine(Path.GetTempPath(), $"lingarr-db-{Guid.NewGuid():N}.db");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SQLITE_DB_PATH", dbPath);
+
+            var options = new DbContextOptionsBuilder<LingarrDbContext>();
+            DatabaseConfiguration.ConfigureDbContext(options, "sqlite");
+
+            await using var context = new LingarrDbContext(options.Options);
+            await context.Database.OpenConnectionAsync();
+
+            var connection = (SqliteConnection)context.Database.GetDbConnection();
+
+            Assert.Equal("wal", await ExecuteScalarAsync(connection, "PRAGMA journal_mode;"));
+            Assert.Equal(120000, await ExecuteScalarIntAsync(connection, "PRAGMA busy_timeout;"));
+            Assert.Equal(1, await ExecuteScalarIntAsync(connection, "PRAGMA synchronous;"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SQLITE_DB_PATH", originalSqliteDbPath);
+            SqliteConnection.ClearAllPools();
+
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+
+    private static async Task<object?> ExecuteScalarAsync(SqliteConnection connection, string commandText)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        return await command.ExecuteScalarAsync();
+    }
+
+    private static async Task<int> ExecuteScalarIntAsync(SqliteConnection connection, string commandText)
+    {
+        var result = await ExecuteScalarAsync(connection, commandText);
+        return Convert.ToInt32(result);
+    }
+}


### PR DESCRIPTION
## Summary
- Apply SQLite WAL, busy_timeout, and synchronous pragmas to the main Lingarr DbContext
- Use a connection interceptor so the pragmas are applied whenever the DB connection opens
- Allow absolute SQLITE_DB_PATH values so tests and non-container deployments can use a temporary file path
- Add a regression test that verifies the SQLite pragmas are active on a live connection

## Verification
- `git diff --check`
- Could not run `dotnet test` in this shell because `dotnet` is not installed here

Related issue: https://github.com/lingarr-translate/lingarr/issues/424#issuecomment-4478694875