### PR TITLE
fix: on npgsql convert DateTime to utc

### DIFF
--- a/Lingarr.Core/Data/LingarrDbContext.cs
+++ b/Lingarr.Core/Data/LingarrDbContext.cs
@@ -33,6 +33,37 @@ public class LingarrDbContext : DbContext
         modelBuilder.ApplyConfiguration(new SeasonConfiguration());
         modelBuilder.ApplyConfiguration(new EpisodeConfiguration());
         modelBuilder.ApplyConfiguration(new ImageConfiguration());
+
+        if (Database.IsNpgsql())
+        {
+            ConvertDateTimePropertiesToUtc(modelBuilder);
+        }
+    }
+
+    private static void ConvertDateTimePropertiesToUtc(ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTime))
+                {
+                    property.SetValueConverter(new Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<DateTime, DateTime>(
+                        v => v.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(v, DateTimeKind.Utc) : v.ToUniversalTime(),
+                        v => v));
+                }
+                else if (property.ClrType == typeof(DateTime?))
+                {
+                    property.SetValueConverter(new Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<DateTime?, DateTime?>(
+                        v => v.HasValue 
+                            ? (v.Value.Kind == DateTimeKind.Unspecified 
+                                ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) 
+                                : v.Value.ToUniversalTime()) 
+                            : v,
+                        v => v));
+                }
+            }
+        }
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/Lingarr.Migrations/MigrationConfiguration.cs
+++ b/Lingarr.Migrations/MigrationConfiguration.cs
@@ -155,7 +155,7 @@ public static class MigrationConfiguration
         {
             "sqlite" => $"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='{tableName}'",
             "mysql" => $"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '{tableName}'",
-            "postgres" or "postgresql" => $"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '{tableName}'",
+            "postgres" or "postgresql" => $"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = '{tableName}'",
             _ => $"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='{tableName}'"
         };
 
@@ -188,7 +188,7 @@ public static class MigrationConfiguration
             )",
             "postgres" or "postgresql" => $@"CREATE TABLE IF NOT EXISTS ""{VersionTableName}"" (
                 ""version"" BIGINT NOT NULL,
-                ""applied_on"" TIMESTAMP,
+                ""applied_on"" TIMESTAMP WITH TIME ZONE,
                 ""description"" VARCHAR(1024)
             )",
             _ => $@"CREATE TABLE IF NOT EXISTS ""{VersionTableName}"" (
@@ -210,7 +210,7 @@ public static class MigrationConfiguration
         command.CommandText = dbConnection.ToLowerInvariant() switch
         {
             "mysql" => $"INSERT INTO {VersionTableName} (version, applied_on, description) VALUES ({version}, '{now:yyyy-MM-dd HH:mm:ss}', '{description}')",
-            "postgres" or "postgresql" => $"INSERT INTO \"{VersionTableName}\" (\"version\", \"applied_on\", \"description\") VALUES ({version}, '{now:yyyy-MM-dd HH:mm:ss}', '{description}')",
+            "postgres" or "postgresql" => $"INSERT INTO \"{VersionTableName}\" (\"version\", \"applied_on\", \"description\") VALUES ({version}, '{now:yyyy-MM-dd HH:mm:ss}Z', '{description}')",
             _ => $"INSERT INTO \"{VersionTableName}\" (\"version\", \"applied_on\", \"description\") VALUES ({version}, '{now:yyyy-MM-dd HH:mm:ss}', '{description}')"
         };
 


### PR DESCRIPTION
- added npgsql only DateTime to UTC value converter at DBContext level
    - If `Kind` is `Unspecified`, it specifies it as `Utc`.
    - If it's already specified but not UTC, it converts it to UTC.
- update version_info to use UTC timestamp:
    - Updated  `version_info` table creation in `MigrationConfiguration` to use `TIMESTAMP WITH TIME ZONE` for PostgreSQL.