### PR TITLE
fix(local-ai): retry batch translation on unparsable model response

### DIFF
--- a/Lingarr.Server.Tests/Services/Translation/LocalAiServiceTests.cs
+++ b/Lingarr.Server.Tests/Services/Translation/LocalAiServiceTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Lingarr.Contracts.Exceptions;
+using Lingarr.Contracts.Models.Batch;
+using Lingarr.Core.Configuration;
+using Lingarr.Server.Exceptions;
+using Lingarr.Server.Interfaces.Services;
+using Lingarr.Server.Services;
+using Lingarr.Server.Services.Translation;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Lingarr.Server.Tests.Services.Translation;
+
+public class LocalAiServiceTests
+{
+    private const string GenerateEndpoint = "http://localhost:11434/api/generate";
+    private const string ChatEndpoint = "http://localhost:11434/v1/chat/completions";
+
+    /// <summary>
+    /// A response where the model left an unescaped quote inside a translated line, the failure
+    /// mode reported in issue #456 for small local models such as gemma4:e4b.
+    /// </summary>
+    private const string MalformedJson =
+        "[{\"position\":1,\"line\":\"Hola\"},{\"position\":2,\"line\":\"Él dijo \"adiós\" y se fue\"}]";
+
+    private const string ValidJson =
+        "[{\"position\":1,\"line\":\"Hola\"},{\"position\":2,\"line\":\"Mundo\"}]";
+
+    private readonly Mock<ISettingService> _settingsMock;
+    private readonly Mock<ILogger<LocalAiService>> _loggerMock;
+    private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock;
+    private readonly LocalAiService _service;
+
+    public LocalAiServiceTests()
+    {
+        _settingsMock = new Mock<ISettingService>();
+        _loggerMock = new Mock<ILogger<LocalAiService>>();
+        _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+        _settingsMock.Setup(settingService => settingService.GetEncryptedSetting(It.IsAny<string>()))
+            .ReturnsAsync(string.Empty);
+
+        _service = new LocalAiService(
+            _settingsMock.Object,
+            new HttpClient(_httpMessageHandlerMock.Object),
+            _loggerMock.Object,
+            new LanguageCodeService(),
+            new RequestTemplateService());
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_ShouldRetry_WhenGenerateApiReturnsMalformedJson()
+    {
+        // Arrange
+        UseSettings(GenerateEndpoint);
+        SetupResponseSequence(GenerateResponse(MalformedJson), GenerateResponse(ValidJson));
+
+        // Act
+        var result = await _service.TranslateBatchAsync(Batch(), "en", "es", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Hola", result[1]);
+        Assert.Equal("Mundo", result[2]);
+        VerifyRequestsSent(2);
+        VerifyWarningLogged("returned an unparsable response", Times.Once());
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_ShouldThrow_WhenGenerateApiKeepsReturningMalformedJson()
+    {
+        // Arrange
+        UseSettings(GenerateEndpoint);
+        SetupResponse(() => GenerateResponse(MalformedJson));
+
+        // Act
+        var exception = await Assert.ThrowsAsync<TranslationException>(
+            () => _service.TranslateBatchAsync(Batch(), "en", "es", CancellationToken.None));
+
+        // Assert
+        Assert.Contains("Retry limit reached", exception.Message);
+        Assert.IsType<TranslationParseException>(exception.InnerException);
+        VerifyRequestsSent(3); // MaxRetries
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_ShouldRetry_WhenChatApiFallbackReturnsMalformedJson()
+    {
+        // Arrange
+        UseSettings(ChatEndpoint);
+
+        // The chat endpoint tries structured output first and falls back to plain JSON parsing,
+        // so a failing attempt sends two requests before the retry kicks in.
+        SetupResponseSequence(
+            ChatResponse(MalformedJson),
+            ChatResponse(MalformedJson),
+            ChatResponse("{\"translations\":" + ValidJson + "}"));
+
+        // Act
+        var result = await _service.TranslateBatchAsync(Batch(), "en", "es", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Mundo", result[2]);
+        VerifyRequestsSent(3);
+        VerifyWarningLogged("returned an unparsable response", Times.Once());
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_ShouldNotRetry_WhenRequestFailsWithNonRetryableStatus()
+    {
+        // Arrange
+        UseSettings(GenerateEndpoint);
+        SetupResponse(() => new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.BadRequest,
+            Content = new StringContent("{\"error\":\"model not found\"}", Encoding.UTF8, "application/json")
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<TranslationException>(
+            () => _service.TranslateBatchAsync(Batch(), "en", "es", CancellationToken.None));
+
+        // Assert
+        Assert.Contains("Unexpected error", exception.Message);
+        VerifyRequestsSent(1);
+    }
+
+    private static List<BatchSubtitleItem> Batch() =>
+    [
+        new() { Position = 1, Line = "Hello" },
+        new() { Position = 2, Line = "World" }
+    ];
+
+    private static HttpResponseMessage GenerateResponse(string translatedJson) =>
+        JsonResponse(new { model = "gemma4:e4b", response = translatedJson, done = true });
+
+    private static HttpResponseMessage ChatResponse(string translatedJson) =>
+        JsonResponse(new { choices = new[] { new { message = new { content = translatedJson } } } });
+
+    private static HttpResponseMessage JsonResponse(object body) => new()
+    {
+        StatusCode = HttpStatusCode.OK,
+        Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+    };
+
+    private void UseSettings(string endpoint)
+    {
+        var settings = new Dictionary<string, string>
+        {
+            { SettingKeys.Translation.LocalAi.Model, "gemma4:e4b" },
+            { SettingKeys.Translation.LocalAi.Endpoint, endpoint },
+            { SettingKeys.Translation.LocalAi.ChatRequestTemplate, "" },
+            { SettingKeys.Translation.LocalAi.GenerateRequestTemplate, "" },
+            { SettingKeys.Translation.AiPrompt, "Translate from {sourceLanguage} to {targetLanguage}" },
+            { SettingKeys.Translation.AiUserPrompt, "{lineToTranslate}" },
+            { SettingKeys.Translation.RequestTimeout, "5" },
+            { SettingKeys.Translation.MaxRetries, "3" },
+            { SettingKeys.Translation.RetryDelay, "0" }, // No delay to keep the tests fast
+            { SettingKeys.Translation.RetryDelayMultiplier, "1" },
+            { SettingKeys.Translation.LanguageCodeFormat, "false" }
+        };
+
+        _settingsMock.Setup(settingService => settingService.GetSettings(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(settings);
+    }
+
+    /// <summary>
+    /// Answers every request with a freshly built response, so an attempt never reads content
+    /// that a previous attempt already consumed.
+    /// </summary>
+    private void SetupResponse(Func<HttpResponseMessage> responseFactory)
+    {
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() => Task.FromResult(responseFactory()));
+    }
+
+    private void SetupResponseSequence(params HttpResponseMessage[] responses)
+    {
+        var sequence = _httpMessageHandlerMock.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        foreach (var response in responses)
+        {
+            sequence = sequence.ReturnsAsync(response);
+        }
+    }
+
+    private void VerifyRequestsSent(int count)
+    {
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(count),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    private void VerifyWarningLogged(string message, Times times)
+    {
+        _loggerMock.Verify(
+            logger => logger.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((value, _) => value.ToString()!.Contains(message)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+    }
+}

--- a/Lingarr.Server/Exceptions/TranslationParseException.cs
+++ b/Lingarr.Server/Exceptions/TranslationParseException.cs
@@ -1,0 +1,20 @@
+using Lingarr.Contracts.Exceptions;
+
+namespace Lingarr.Server.Exceptions;
+
+/// <summary>
+/// Raised when a translation provider returns a response that cannot be parsed into translated
+/// subtitles. AI models sample their output, so the same request usually succeeds when retried,
+/// which makes this failure retryable unlike a configuration or transport error.
+/// </summary>
+public class TranslationParseException : TranslationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TranslationParseException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="exception">The exception that caused the parse failure, if any.</param>
+    public TranslationParseException(string message, Exception? exception = null) : base(message, exception)
+    {
+    }
+}

--- a/Lingarr.Server/Services/Translation/LocalAiService.cs
+++ b/Lingarr.Server/Services/Translation/LocalAiService.cs
@@ -183,7 +183,8 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
     /// <summary>
     /// Translates a batch of subtitles in a single API call using structured outputs fallback
     /// Since LocalAI may not support structured outputs, we'll attempt structured format first,
-    /// then fall back to regular parsing if needed
+    /// then fall back to regular parsing if needed. Responses that cannot be parsed are retried
+    /// using the configured retry settings, as local models occasionally emit malformed JSON.
     /// </summary>
     /// <param name="subtitleBatch">List of subtitles with position and content</param>
     /// <param name="sourceLanguage">Source language code</param>
@@ -222,6 +223,21 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
                 _logger.LogWarning(
                     "{ServiceName} received {StatusCode}. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
                     "LocalAI", ex.StatusCode, delay, attempt, _maxRetries);
+            }
+            catch (TranslationParseException ex)
+            {
+                if (attempt == _maxRetries)
+                {
+                    _logger.LogError(ex, "Max retries exhausted for batch translation, the model kept returning an unparsable response");
+                    throw new TranslationException("Retry limit reached after unparsable response.", ex);
+                }
+
+                _logger.LogWarning(
+                    "{ServiceName} returned an unparsable response. Retrying in {Delay}... (Attempt {Attempt}/{MaxRetries})",
+                    "LocalAI", delay, attempt, _maxRetries);
+
+                await Task.Delay(delay, linked.Token).ConfigureAwait(false);
+                delay = TimeSpan.FromTicks(delay.Ticks * _retryDelayMultiplier);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -343,7 +359,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
             var responseWrapper = JsonSerializer.Deserialize<JsonElement>(translatedJson);
             if (!responseWrapper.TryGetProperty("translations", out var translationsElement))
             {
-                throw new TranslationException("Response does not contain 'translations' property");
+                throw new TranslationParseException("Response does not contain 'translations' property");
             }
 
             var translatedItems =
@@ -351,7 +367,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
 
             if (translatedItems == null)
             {
-                throw new TranslationException("Failed to deserialize translated subtitles");
+                throw new TranslationParseException("Failed to deserialize translated subtitles");
             }
 
             return MergeByPosition(translatedItems);
@@ -359,7 +375,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
         catch (JsonException ex)
         {
             _logger.LogError(ex, "Failed to parse structured JSON response: {Json}", translatedJson);
-            throw new TranslationException("Failed to parse structured translated subtitles", ex);
+            throw new TranslationParseException("Failed to parse structured translated subtitles", ex);
         }
     }
 
@@ -414,7 +430,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
 
             if (translatedItems == null)
             {
-                throw new TranslationException("Failed to deserialize translated subtitles from JSON parsing");
+                throw new TranslationParseException("Failed to deserialize translated subtitles from JSON parsing");
             }
 
             return MergeByPosition(translatedItems);
@@ -422,7 +438,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
         catch (JsonException ex)
         {
             _logger.LogError(ex, "Failed to parse JSON response: {Json}", translatedJson);
-            throw new TranslationException("Failed to parse JSON translated subtitles", ex);
+            throw new TranslationParseException("Failed to parse JSON translated subtitles", ex);
         }
     }
 
@@ -478,7 +494,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
 
             if (translatedItems == null)
             {
-                throw new TranslationException("Failed to deserialize translated subtitles from generate API");
+                throw new TranslationParseException("Failed to deserialize translated subtitles from generate API");
             }
 
             return MergeByPosition(translatedItems);
@@ -486,7 +502,7 @@ public class LocalAiService : BaseLanguageService, ITranslationService, IBatchTr
         catch (JsonException ex)
         {
             _logger.LogError(ex, "Failed to parse generate API JSON response: {Json}", translatedJson);
-            throw new TranslationException("Failed to parse generate API translated subtitles", ex);
+            throw new TranslationParseException("Failed to parse generate API translated subtitles", ex);
         }
     }
 


### PR DESCRIPTION
Local models occasionally emit malformed JSON, which aborted the entire translation job on the first failure. The retry loop in TranslateBatchAsync only covered HTTP 429/503, so a parse failure fell through to the generic catch and was rethrown immediately, meaning MaxRetries never applied to it.

Parse failures in the three batch paths now throw TranslationParseException and are retried using the configured MaxRetries, RetryDelay and RetryDelayMultiplier settings. Failures that will not improve on a retry, such as an HTTP 400 for a missing model, still fail on the first attempt.

Fixes #456